### PR TITLE
#89: cleanup dashboard filter layout styles

### DIFF
--- a/src/app/dashboard/filter/dashboard-filter.component.scss
+++ b/src/app/dashboard/filter/dashboard-filter.component.scss
@@ -1,22 +1,43 @@
+:host {
+  ::ng-deep {
+    .mat-form-field {
+      display: inline;
+    }
+
+    .mat-form-field-infix {
+      width: 100%;
+    }
+
+    .mat-form-field-outline:not(.mat-form-field-outline-thick) {
+      .mat-form-field-outline-start,
+      .mat-form-field-outline-end {
+        background-color: white
+      }
+    }
+  }
+}
+
 h1 {
   font-weight: 700;
   font-size: 1.75em;
   line-height: 2em;
   color: #676767;
-}
-div {
-  display: flex;
+  white-space: nowrap;
 }
 .dates {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(46vw, 1fr));
   justify-content: space-between;
 }
 .selects {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(30vw, 1fr));
+  grid-column-gap: 10px;
   justify-content: space-between;
-  flex-wrap: wrap;
 }
 .text {
-  justify-content: flex-start;
-}
-grove-filter-text + grove-filter-text {
-  margin-left: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(45vw, 1fr));
+  grid-column-gap: 10px;
+  justify-content: space-between;
 }

--- a/src/app/dashboard/filter/filter-date.component.scss
+++ b/src/app/dashboard/filter/filter-date.component.scss
@@ -1,10 +1,13 @@
 /* have to override the global button styles */
+:host {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-column-gap: 10px;
+}
+
 ::ng-deep button {
   flex: initial;
 }
 ::ng-deep button:hover, ::ng-deep button[disabled] {
   background-color: initial;
-}
-mat-form-field + mat-form-field {
-  margin-left: 10px;
 }


### PR DESCRIPTION
#89 

- Cleans up dashboard filter input layout.
- Adds white background to filter inputs.

## To Review
- [ ] Checkout branch.
- [ ] Run `docker-compose build`.
- [ ] Run `docker-compose up`.
- [ ] Go to [grove.prx.docker](https://grove.prx.docker).
- [ ] Ensure filter inputs layout cleanly and responsively across screen sizes.