### PR TITLE
Fix campaign owner field

### DIFF
--- a/src/app/campaign/campaign.component.spec.ts
+++ b/src/app/campaign/campaign.component.spec.ts
@@ -1,5 +1,6 @@
 import { CampaignComponent } from './campaign.component';
-import { CampaignStoreService, CampaignState, FlightState, AdvertiserService } from '../core';
+import { CampaignStoreService, CampaignState, FlightState, AccountService, AdvertiserService } from '../core';
+import { AccountServiceMock } from '../core/account/account.service.mock';
 import { AdvertiserServiceMock } from '../core/advertiser/advertiser.service.mock';
 import { ReplaySubject, of } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -10,6 +11,7 @@ describe('CampaignComponent', () => {
   let routeId: ReplaySubject<string>;
   let route: ActivatedRoute;
   let router: Router;
+  let accountService: AccountService;
   let advertiserService: AdvertiserService;
   let toastrService: ToastrService;
   let campaignStoreService: CampaignStoreService;
@@ -55,7 +57,8 @@ describe('CampaignComponent', () => {
       setFlight: jest.fn()
     } as any;
     advertiserService = new AdvertiserServiceMock(new MockHalService()) as any;
-    component = new CampaignComponent(route, router, toastrService, campaignStoreService, advertiserService);
+    accountService = new AccountServiceMock() as any;
+    component = new CampaignComponent(route, router, toastrService, campaignStoreService, accountService, advertiserService);
     component.ngOnInit();
   });
 
@@ -74,7 +77,10 @@ describe('CampaignComponent', () => {
     const flight2 = flightFactory({ name: 'Name 2' });
     campaignState.next({ ...campaign, flights: { flight1, flight2 } });
     component.campaignFlights$.subscribe(options => {
-      expect(options).toMatchObject([{ id: 'flight1', name: 'Name 1' }, { id: 'flight2', name: 'Name 2' }]);
+      expect(options).toMatchObject([
+        { id: 'flight1', name: 'Name 1' },
+        { id: 'flight2', name: 'Name 2' }
+      ]);
       done();
     });
   });

--- a/src/app/campaign/campaign.component.ts
+++ b/src/app/campaign/campaign.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, OnInit, OnDestroy } from '@angular/
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { Observable, Subscription } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
-import { CampaignStoreService, AdvertiserService } from '../core';
+import { CampaignStoreService, AdvertiserService, AccountService } from '../core';
 import { ToastrService } from 'ngx-prx-styleguide';
 
 @Component({
@@ -49,6 +49,7 @@ export class CampaignComponent implements OnInit, OnDestroy {
     private router: Router,
     private toastr: ToastrService,
     public campaignStoreService: CampaignStoreService,
+    private accountService: AccountService,
     private advertiserService: AdvertiserService
   ) {}
 
@@ -57,9 +58,12 @@ export class CampaignComponent implements OnInit, OnDestroy {
       .pipe(
         switchMap((params: ParamMap) => {
           return this.advertiserService.loadAdvertisers().pipe(map(advertisers => ({ params, advertisers })));
+        }),
+        switchMap(({ params, advertisers }) => {
+          return this.accountService.loadAccounts().pipe(map(accounts => ({ params, advertisers, accounts })));
         })
       )
-      .subscribe(({ params, advertisers }) => {
+      .subscribe(({ params, advertisers, accounts }) => {
         this.campaignStoreService.load(params.get('id'));
       });
     this.campaignFlights$ = this.campaignStoreService.flights$.pipe(

--- a/src/app/campaign/flight/flight.container.spec.ts
+++ b/src/app/campaign/flight/flight.container.spec.ts
@@ -94,7 +94,8 @@ describe('FlightContainerComponent', () => {
     });
   });
 
-  it('redirects to campaign if the flight does not exist', () => {
+  // TODO: no longer does this because it caused a premature navigation bug, should we create a better way to detect it?
+  xit('redirects to campaign if the flight does not exist', () => {
     campaign.next({ flights: { 123: { name: 'my-flight' } } });
     routeId.next('456');
     expect(router.navigate).toHaveBeenCalledWith(['/campaign', 'new']);

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -94,10 +94,10 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
       this.currentFlightId = id;
       this.flightState$.next(state.flights[id]);
       this.currentInventoryUri$.next(state.flights[id].localFlight.set_inventory_uri);
-    } else {
-      const campaignId = state.remoteCampaign ? state.remoteCampaign.id : 'new';
-      this.router.navigate(['/campaign', campaignId]);
-    }
+    } /*
+    else {
+      TODO: what to do about an invalid flight id and how to tell if a flight doesn't exist or hasn't yet been loaded into state
+    }*/
   }
 
   flightUpdateFromForm({ flight, changed, valid }) {

--- a/src/app/campaign/form/campaign-form.container.spec.ts
+++ b/src/app/campaign/form/campaign-form.container.spec.ts
@@ -11,7 +11,7 @@ describe('CampaignFormContainerComponent', () => {
   let component: CampaignFormContainerComponent;
 
   beforeEach(() => {
-    accountService = { listAccounts: jest.fn(() => of([])) } as any;
+    accountService = { loadAccounts: jest.fn(() => of([])) } as any;
     advertiserService = new AdvertiserServiceMock(new MockHalService()) as any;
     campaignStoreService = { localCampaign$: of({}), setCampaign: jest.fn(() => of({})) } as any;
     component = new CampaignFormContainerComponent(campaignStoreService, accountService, advertiserService);

--- a/src/app/campaign/form/campaign-form.container.ts
+++ b/src/app/campaign/form/campaign-form.container.ts
@@ -18,16 +18,14 @@ import { withLatestFrom } from 'rxjs/operators';
 })
 export class CampaignFormContainerComponent {
   campaign$: Observable<Campaign> = this.campaignStoreService.localCampaign$;
-  accounts$: Observable<Account[]>;
+  accounts$: Observable<Account[]> = this.accountService.accounts;
   advertisers$: Observable<Advertiser[]> = this.advertiserService.advertisers;
 
   constructor(
     public campaignStoreService: CampaignStoreService,
     private accountService: AccountService,
     private advertiserService: AdvertiserService
-  ) {
-    this.accounts$ = this.accountService.listAccounts();
-  }
+  ) {}
 
   campaignUpdateFromForm(newState: { campaign: Campaign; changed: boolean; valid: boolean }) {
     const { campaign, changed, valid } = newState;
@@ -41,7 +39,7 @@ export class CampaignFormContainerComponent {
       // TODO: how are we notifying in this app, material or the ol' toast?
       // this.toastr.success('Advertiser added');
       this.campaignStoreService.setCampaign({
-        localCampaign: {...campaign, set_advertiser_uri: result.set_advertiser_uri},
+        localCampaign: { ...campaign, set_advertiser_uri: result.set_advertiser_uri },
         changed: true,
         valid: true
       });

--- a/src/app/core/account/account.service.mock.ts
+++ b/src/app/core/account/account.service.mock.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Account } from './account.service';
+
+export const accounts: Account[] = [
+  {
+    id: 1,
+    name: 'Person',
+    self_uri: '/api/v1/accounts/1'
+  },
+  {
+    id: 28,
+    name: 'A Group Account',
+    self_uri: '/api/v1/accounts/28'
+  }
+];
+
+@Injectable()
+export class AccountServiceMock {
+  // tslint:disable-next-line: variable-name
+  _accounts = new BehaviorSubject<Account[]>(accounts);
+
+  loadAccounts(): Observable<Account[]> {
+    return this.accounts;
+  }
+
+  get accounts(): Observable<Account[]> {
+    return this._accounts.asObservable();
+  }
+}

--- a/src/app/core/account/account.service.spec.ts
+++ b/src/app/core/account/account.service.spec.ts
@@ -10,8 +10,8 @@ describe('AccountService', () => {
     account = new AccountService(user as any);
   });
 
-  it('lists accounts', done => {
-    account.listAccounts().subscribe(accounts => {
+  it('loads accounts', done => {
+    account.loadAccounts().subscribe(accounts => {
       expect(accounts.length).toEqual(2);
       expect(accounts[0]).toMatchObject({ id: 12 });
       expect(accounts[1]).toMatchObject({ id: 11 });

--- a/src/app/core/campaign/campaign.service.ts
+++ b/src/app/core/campaign/campaign.service.ts
@@ -3,7 +3,7 @@ import { Observable, of } from 'rxjs';
 import { map, switchMap, catchError } from 'rxjs/operators';
 import { HalDoc } from 'ngx-prx-styleguide';
 import { AuguryService } from '../augury.service';
-import { CampaignState, Campaign, Flight, FlightState, Availability } from './campaign.models';
+import { CampaignState, Campaign, Flight, FlightState } from './campaign.models';
 
 @Injectable()
 export class CampaignService {
@@ -13,7 +13,7 @@ export class CampaignService {
   constructor(private augury: AuguryService) {}
 
   getCampaign(id: number | string): Observable<CampaignState> {
-    return this.augury.follow('prx:campaign', { id, zoom: 'prx:flights' }).pipe(
+    return this.augury.follow('prx:campaign', { id }).pipe(
       switchMap(doc => doc.followItems('prx:flights').pipe(map(flightDocs => ({ doc, flightDocs })))),
       map(({ doc, flightDocs }) => {
         this.campaignDoc = doc;

--- a/src/app/core/campaign/campaign.service.ts
+++ b/src/app/core/campaign/campaign.service.ts
@@ -14,7 +14,10 @@ export class CampaignService {
 
   getCampaign(id: number | string): Observable<CampaignState> {
     return this.augury.follow('prx:campaign', { id }).pipe(
-      switchMap(doc => doc.followItems('prx:flights').pipe(map(flightDocs => ({ doc, flightDocs })))),
+      switchMap(doc => doc.follow('prx:flights').pipe(map(flights => ({ doc, flights })))),
+      switchMap(({ doc, flights }: { doc: HalDoc; flights: HalDoc }) =>
+        doc.followItems('prx:flights', { per: +flights['total'] }).pipe(map(flightDocs => ({ doc, flightDocs })))
+      ),
       map(({ doc, flightDocs }) => {
         this.campaignDoc = doc;
         this.flightDocs = flightDocs.reduce((accum, flight) => ({ ...accum, [flight.id]: flight }), {});


### PR DESCRIPTION
Fixes the campaign owner field to load the campaign after the accounts have been loaded.

Also a workaround on the issue currently on campaign/flights zoom where the embedded flights list is not paged, and Hal is not handling it. I removed the zoom on flights there to get around the error.