### PR TITLE
gets the allocation preview for saved flights

### DIFF
--- a/src/app/core/allocation/allocation-preview.service.spec.ts
+++ b/src/app/core/allocation/allocation-preview.service.spec.ts
@@ -50,11 +50,32 @@ describe('AllocationPreviewService', () => {
 
   beforeEach(() => {
     augury.mock('prx:flight-allocation-preview', allocationPreviewFixture);
+    augury.mock('prx:flight', { id: 1 }).mock('preview', allocationPreviewFixture);
   });
 
-  it('gets allocation preview', done => {
+  it('gets allocation preview for unsaved flights', done => {
     allocationPreviewService
       .getAllocationPreview({
+        id: undefined,
+        startAt: '2019-10-01',
+        endAt: '2019-11;01',
+        name: 'flight 1',
+        set_inventory_uri: '/some/url',
+        zones: ['pre_1'],
+        totalGoal: 999,
+        dailyMinimum: 90
+      })
+      .subscribe(alloc => {
+        const { startAt, endAt, dailyMinimum, totalGoal, zones } = allocationPreview;
+        expect(alloc).toMatchObject({ startAt, endAt, dailyMinimum, totalGoal, zones });
+        done();
+      });
+  });
+
+  it('gets allocation preview for saved flights', done => {
+    allocationPreviewService
+      .getAllocationPreview({
+        id: 1,
         startAt: '2019-10-01',
         endAt: '2019-11;01',
         name: 'flight 1',

--- a/src/app/core/allocation/allocation-preview.service.spec.ts
+++ b/src/app/core/allocation/allocation-preview.service.spec.ts
@@ -4,7 +4,8 @@ import { AuguryService } from '../augury.service';
 
 describe('AllocationPreviewService', () => {
   const augury = new MockHalService();
-  const allocationPreviewService = new AllocationPreviewService(new AuguryService(augury as any));
+  const auguryService = new AuguryService(augury as any);
+  const allocationPreviewService = new AllocationPreviewService(auguryService);
   const allocationPreviewFixture = {
     startAt: '2019-10-01',
     endAt: '2019-11-01',
@@ -73,6 +74,7 @@ describe('AllocationPreviewService', () => {
   });
 
   it('gets allocation preview for saved flights', done => {
+    jest.spyOn(auguryService, 'follow');
     allocationPreviewService
       .getAllocationPreview({
         id: 1,
@@ -84,9 +86,8 @@ describe('AllocationPreviewService', () => {
         totalGoal: 999,
         dailyMinimum: 90
       })
-      .subscribe(alloc => {
-        const { startAt, endAt, dailyMinimum, totalGoal, zones } = allocationPreview;
-        expect(alloc).toMatchObject({ startAt, endAt, dailyMinimum, totalGoal, zones });
+      .subscribe(() => {
+        expect(auguryService.follow).toHaveBeenCalledWith('prx:flight', { id: 1 });
         done();
       });
   });

--- a/src/app/core/campaign/campaign-store.service.ts
+++ b/src/app/core/campaign/campaign-store.service.ts
@@ -232,7 +232,7 @@ export class CampaignStoreService {
           dailyMinimum = state.dailyMinimum[`${flightId || id}`];
         }
         return this.allocationPreviewService.getAllocationPreview({
-          ...(id === +flightId && { id }),
+          id,
           set_inventory_uri,
           name,
           startAt,

--- a/src/app/core/campaign/campaign-store.service.ts
+++ b/src/app/core/campaign/campaign-store.service.ts
@@ -232,6 +232,7 @@ export class CampaignStoreService {
           dailyMinimum = state.dailyMinimum[`${flightId || id}`];
         }
         return this.allocationPreviewService.getAllocationPreview({
+          ...(id === +flightId && { id }),
           set_inventory_uri,
           name,
           startAt,

--- a/src/app/core/campaign/campaign-store.service.ts
+++ b/src/app/core/campaign/campaign-store.service.ts
@@ -13,7 +13,7 @@ import {
   AllocationPreview
 } from './campaign.models';
 import { ReplaySubject, Observable, forkJoin, of } from 'rxjs';
-import { map, first, switchMap, share, withLatestFrom, mergeMap } from 'rxjs/operators';
+import { map, first, switchMap, share, withLatestFrom, concatMap } from 'rxjs/operators';
 import { HalDoc } from 'ngx-prx-styleguide';
 
 @Injectable({ providedIn: 'root' })
@@ -227,7 +227,7 @@ export class CampaignStoreService {
     startAt = new Date(startAt.valueOf()).toISOString().slice(0, 10);
     endAt = new Date(endAt.valueOf()).toISOString().slice(0, 10);
     const loading = this._campaign$.pipe(
-      mergeMap(state => {
+      concatMap(state => {
         if (!dailyMinimum && dailyMinimum !== 0 && state.dailyMinimum) {
           dailyMinimum = state.dailyMinimum[`${flightId || id}`];
         }


### PR DESCRIPTION
This fixes the allocation preview on saved flights. Previously, it was just pulling the unsaved flight preview. For flights that have been created, this now pulls that flight's allocation preview with any 'preview' parameters that may be different from the persisted flight.