### PR TITLE
fixes loading flight allocation preview on form change

### DIFF
--- a/src/app/campaign/flight/flight.container.spec.ts
+++ b/src/app/campaign/flight/flight.container.spec.ts
@@ -94,6 +94,42 @@ describe('FlightContainerComponent', () => {
     });
   });
 
+  it('does not load allocation preview if flight name changes', () => {
+    const flight = {
+      id: 123,
+      name: 'my-flight'
+    };
+    campaign.next({
+      flights: {
+        123: {
+          localFlight: flight
+        }
+      },
+      availability: {}
+    });
+    routeId.next('123');
+    component.flightUpdateFromForm({ flight: { ...flight, name: 'my-other-flight' }, changed: true, valid: true });
+    expect(campaignStoreService.loadAllocationPreview).not.toHaveBeenCalled();
+  });
+
+  it('does not load allocation preview if id does not match flight in state', () => {
+    const flight = {
+      id: 123,
+      name: 'my-flight'
+    };
+    campaign.next({
+      flights: {
+        123: {
+          localFlight: flight
+        }
+      },
+      availability: {}
+    });
+    routeId.next('123');
+    component.flightUpdateFromForm({ flight: { id: 124, name: 'New Flight 124' }, changed: true, valid: true });
+    expect(campaignStoreService.loadAllocationPreview).not.toHaveBeenCalled();
+  });
+
   // TODO: no longer does this because it caused a premature navigation bug, should we create a better way to detect it?
   xit('redirects to campaign if the flight does not exist', () => {
     campaign.next({ flights: { 123: { name: 'my-flight' } } });

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -97,6 +97,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
     } /*
     else {
       TODO: what to do about an invalid flight id and how to tell if a flight doesn't exist or hasn't yet been loaded into state
+      TODO: I think when I removed this, it broke the browser refresh on a new flight form, just shows loading spinner
     }*/
   }
 
@@ -112,6 +113,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
         filter((flightState: FlightState) => {
           // determine if the availability fields are present and have changed since the last update from form
           const { localFlight } = flightState;
+          const idMatch = flight.id === localFlight.id;
           // dates come back as Date but typed string on Flight
           const flightStartAtDate = flight.startAt && new Date(flight.startAt.valueOf());
           const flightEndAtDate = flight.endAt && new Date(flight.endAt.valueOf());
@@ -124,7 +126,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
               flightEndAtDate.valueOf() !== new Date(localFlight.endAt).valueOf() ||
               flight.set_inventory_uri !== localFlight.set_inventory_uri ||
               !flight.zones.every(zone => localFlight.zones.indexOf(zone) > -1));
-          return dateRangeValid && availabilityParamsChanged;
+          return idMatch && dateRangeValid && availabilityParamsChanged;
         }),
         first()
       )


### PR DESCRIPTION
When opening a new flight form, I found there is an async issue between updating the state and the form updates, so I added a change to make sure the flight ids match before loading the availability and allocation preview on form change (in addition to all the other criteria for valid fields.)