### PR TITLE
#111: wire up material theme colors

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,7 +1,14 @@
+@import '~src/sass/variables';
+
 prx-header {
   max-width: 100%;
 }
 
 prx-header a {
   color: #FFFFFF;
+}
+
+main {
+  padding-bottom: 0;
+  background-color: prx-theme-background(app-bar);
 }

--- a/src/app/campaign/availability/availability.component.scss
+++ b/src/app/campaign/availability/availability.component.scss
@@ -3,22 +3,22 @@
 :host {
   margin: 20px 10px 20px 20px;
 }
-h2,
-h3 {
-  font-size: 1rem;
-  margin-bottom: 1rem;
-}
 section {
   margin: 20px 0;
+}
+.title {
+  color: prx-theme-foreground(text);
+  font-size: 1rem;
+  margin-bottom: 1rem;
 }
 .row {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid prx-theme-foreground(divider);
   white-space: nowrap;
 }
 .row.head {
-  border-top: 1px solid #ddd;
+  border-top: 1px solid prx-theme-foreground(divider);
 }
 .row:not(.expand),
 .row.head {

--- a/src/app/campaign/availability/availability.component.ts
+++ b/src/app/campaign/availability/availability.component.ts
@@ -4,7 +4,7 @@ import { Flight, Availability, InventoryZone } from '../../core';
 @Component({
   selector: 'grove-availability',
   template: `
-    <h2>Impressions</h2>
+    <h2 class="title">Impressions</h2>
     <p *ngIf="cantShowInventory(); else inventory">
       Please select Start and End Dates, Series, and Zones to view inventory.
     </p>
@@ -15,7 +15,7 @@ import { Flight, Availability, InventoryZone } from '../../core';
       </ul>
       <mat-divider></mat-divider>
       <section *ngFor="let zone of availabilityZones">
-        <h3>{{ getZoneName(zone.zone) }}</h3>
+        <h3 class="title">{{ getZoneName(zone.zone) }}</h3>
         <div class="row head">
           <div class="date">Week</div>
           <div class="avail">Available</div>

--- a/src/app/campaign/campaign.component.scss
+++ b/src/app/campaign/campaign.component.scss
@@ -7,7 +7,7 @@ mat-drawer-content {
 mat-drawer {
   min-width: 250px;
   max-width: 400px;
-  background: #f0f0f0;
+  background: prx-theme-background(app-bar);
   border-right: none;
 }
 
@@ -16,8 +16,8 @@ mat-drawer {
 
   .mat-list-item {
     transition: border-left 100ms ease-out 0ms;
-    background: #ddd;
-    color: $primary;
+    background: prx-theme-background(tab);
+    color: prx-theme-foreground(tab);
     font-weight: 700;
     margin: 0 0 2px;
     border-left: 0 solid $primary;
@@ -29,8 +29,8 @@ mat-drawer {
     }
 
     &.active-link {
-      background: #fff;
-      color: $primary;
+      background: prx-theme-background(selected-tab);
+      color: prx-theme-foreground(selected-tab);
     }
 
     &.changed {
@@ -61,10 +61,10 @@ mat-drawer {
   align-items: center;
   margin: 0.5rem;
   padding: 0.5rem;
-  border: 1px dashed mat-color($prx-gray, 300);
+  border: 1px dashed prx-theme-foreground(divider);
   text-align: center;
 
   &:hover {
-    background-color: mat-color($prx-gray, 100);
+    background-color: prx-theme-background(selected-tab);
   }
 }

--- a/src/app/campaign/flight/flight.component.html
+++ b/src/app/campaign/flight/flight.component.html
@@ -1,30 +1,30 @@
 <mat-card>
   <form [formGroup]="flightForm" ngNativeValidate>
-    <mat-form-field appearance="outline">
+    <mat-form-field class="flight-form-field" appearance="outline">
       <mat-label>Flight Name</mat-label>
       <input matInput placeholder="Flight Name" formControlName="name" required />
     </mat-form-field>
     <div class="flight-dates">
-      <mat-form-field appearance="outline">
+      <mat-form-field class="flight-form-field" appearance="outline">
         <mat-label>Actual Start Date</mat-label>
         <input matInput [matDatepicker]="startPicker" placeholder="Actual Start date" formControlName="startAt" />
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
       </mat-form-field>
-      <mat-form-field appearance="outline">
+      <mat-form-field class="flight-form-field" appearance="outline">
         <mat-label>Actual End Date</mat-label>
         <input matInput [matDatepicker]="endPicker" placeholder="Actual End date" formControlName="endAt" />
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
       </mat-form-field>
     </div>
-    <mat-form-field appearance="outline">
+    <mat-form-field class="flight-form-field" appearance="outline">
       <mat-label>Series</mat-label>
       <mat-select formControlName="set_inventory_uri" required>
         <mat-option *ngFor="let inv of inventory" [value]="inv.self_uri">{{ inv.podcastTitle }}</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field appearance="outline">
+    <mat-form-field class="flight-form-field" appearance="outline">
       <mat-label>Zones</mat-label>
       <mat-select formControlName="zones" multiple required>
         <mat-option *ngFor="let zone of zoneOptions" [value]="zone.id">{{ zone.label }}</mat-option>

--- a/src/app/campaign/flight/flight.component.scss
+++ b/src/app/campaign/flight/flight.component.scss
@@ -1,5 +1,4 @@
-@import '~src/sass/colors';
-@import '~@angular/material/theming';
+@import '~src/sass/variables';
 
 mat-card {
   min-height: 400px;
@@ -23,18 +22,73 @@ mat-card form > * {
 }
 
 .flight-dates {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-column-gap: 0.5rem;
 }
 .flight-dates > prx-datepicker {
-  flex: 1;
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 3rem;
+  justify-items: center;
+  align-items: center;
   margin-bottom: 20px;
-  ::ng-deep input {
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
     width: 100%;
-    color: mat-color($prx-gray, 900);
+    height: 100%;
+    border: 2px solid prx-theme-foreground(divider, 0.87);
     border-radius: 5px;
+    opacity: 0;
   }
-  &:first-child {
-    margin-right: 20px;
+
+  &:hover, &:focus-within {
+    &::before {
+      transition:
+        opacity 0.6s cubic-bezier(.25,.8,.25,1),
+        border-color 0.6s cubic-bezier(.25,.8,.25,1);
+      opacity: 1;
+    }
+  }
+
+  &:focus-within {
+    &::before {
+      border-color: $primary;
+    }
+    ::ng-deep {
+      prx-icon {
+        color: $primary;
+      }
+    }
+  }
+
+  ::ng-deep {
+    > * {
+      position: relative;
+      grid-row: 1;
+    }
+    input {
+      grid-column: 1 / -1;
+      width: 100%;
+      height: auto;
+      color: prx-theme-foreground(text);
+      border: 1px solid prx-theme-foreground(divider, 0.12);
+      border-radius: 5px;
+      background: none;
+      padding: 1rem 0.75rem;
+    }
+
+    > span {
+      grid-column: 2;
+    }
+
+    prx-icon {
+      transition: color 0.6s cubic-bezier(.25,.8,.25,1);
+      position: unset;
+    }
   }
 }
 

--- a/src/app/campaign/flight/flight.component.scss
+++ b/src/app/campaign/flight/flight.component.scss
@@ -11,10 +11,8 @@ mat-card form > * {
   width: 100%;
 }
 
-.mat-select-value,
-.mat-input-element {
+.flight-form-field {
   font-size: 1rem;
-  color: #555;
 }
 
 .mat-form-field-wrapper {

--- a/src/app/campaign/flight/flight.container.scss
+++ b/src/app/campaign/flight/flight.container.scss
@@ -2,11 +2,6 @@
   display: grid;
   grid-template-columns: 2fr minmax(200px, 400px);
 }
-grove-flight {
-}
-grove-availability {
-  min-width: 200px;
-}
 
 .loading-form {
   display: flex;

--- a/src/app/campaign/form/campaign-form.component.html
+++ b/src/app/campaign/form/campaign-form.component.html
@@ -1,12 +1,13 @@
 <mat-card>
   <form [formGroup]="campaignForm" ngNativeValidate>
-    <mat-form-field appearance="outline">
+    <mat-form-field class="campaign-form-field" appearance="outline">
       <mat-label>Campaign Name</mat-label>
       <input matInput placeholder="Campaign Name" formControlName="name" required />
     </mat-form-field>
 
     <grove-autocomplete
       *ngIf="advertisers"
+      class="campaign-form-field"
       [formGroup]="campaignForm"
       controlName="set_advertiser_uri"
       label="Advertiser"
@@ -14,33 +15,33 @@
       (addOption)="onAddAdvertiser($event)">
     </grove-autocomplete>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field class="campaign-form-field" appearance="outline">
       <mat-label>Campaign Type</mat-label>
       <mat-select formControlName="type" required>
         <mat-option *ngFor="let type of typeOptions" [value]="type.value">{{ type.name }}</mat-option>
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field class="campaign-form-field" appearance="outline">
       <mat-label>Campaign Status</mat-label>
       <mat-select formControlName="status" required>
         <mat-option *ngFor="let status of statusOptions" [value]="status.value">{{ status.name }}</mat-option>
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field class="campaign-form-field" appearance="outline">
       <mat-label>Campaign Rep</mat-label>
       <input matInput placeholder="Campaign Rep" formControlName="repName" required />
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field class="campaign-form-field" appearance="outline">
       <mat-label>Owner</mat-label>
       <mat-select formControlName="set_account_uri" required>
         <mat-option *ngFor="let acct of accounts" [value]="acct.self_uri">{{ acct.name }}</mat-option>
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field class="campaign-form-field" appearance="outline">
       <mat-label>Notes</mat-label>
       <textarea matInput formControlName="notes" placeholder="Enter notes"></textarea>
     </mat-form-field>

--- a/src/app/campaign/form/campaign-form.component.scss
+++ b/src/app/campaign/form/campaign-form.component.scss
@@ -4,15 +4,14 @@ mat-card {
   border-radius: 0;
 }
 
-mat-card form > * {
-  max-width: 600px;
-  width: 100%;
+mat-card form {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(auto, 600px));
+  grid-column-gap: 0.5rem;
 }
 
-.mat-select-value,
-.mat-input-element {
+.campaign-form-field {
   font-size: 1rem;
-  color: #555;
 }
 
 .mat-form-field-wrapper {

--- a/src/app/dashboard/campaign-card/campaign-card.component.scss
+++ b/src/app/dashboard/campaign-card/campaign-card.component.scss
@@ -1,14 +1,13 @@
-@import '~@angular/material/theming';
-@import '~src/sass/colors';
+@import '~src/sass/variables';
 @import '~src/sass/status';
 
 :host {
   display: block;
-  background-color: mat-color($prx-gray, 100);
+  background-color: prx-theme-background(card);
+  color: prx-theme-foreground(text);
 }
 .header {
   height: 3px;
-  background-color: mat-color($prx-gray, 500);
 }
 section {
   padding: 10px;
@@ -16,7 +15,7 @@ section {
 }
 section.loading {
   position: relative;
-  background-color: mat-color($prx-gray, 300);
+  background-color: prx-theme-background(status-bar);
 }
 h3 {
   font-weight: 700;

--- a/src/app/dashboard/campaign-list/campaign-list.component.scss
+++ b/src/app/dashboard/campaign-list/campaign-list.component.scss
@@ -1,8 +1,41 @@
+@import '~src/sass/variables';
+
 ul {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-auto-rows: 1fr;
   grid-gap: 20px;
+}
+
+grove-campaign-card {
+  height: 100%;
+}
+
+prx-paging {
+  display: block;
+  text-align: center;
+}
+
+.paging {
+  ::ng-deep {
+    .paging {
+      color: $primary;
+
+      &[disabled] {
+        color: prx-theme-foreground(disabled);
+      }
+
+      &.active {
+        color: prx-theme-foreground(text);
+      }
+    }
+  }
+}
+
+.count-of-total {
+  text-align: center;
+  color: prx-theme-foreground(text);
+  font-style: italic;
 }
 
 @media (min-width: 768px) {
@@ -15,15 +48,4 @@ ul {
   ul {
     grid-template-columns: repeat(4, 1fr);
   }
-}
-
-prx-paging {
-  display: block;
-  text-align: center;
-}
-
-.count-of-total {
-  text-align: center;
-  color: #676767;
-  font-style: italic;
 }

--- a/src/app/dashboard/campaign-list/campaign-list.component.ts
+++ b/src/app/dashboard/campaign-list/campaign-list.component.ts
@@ -27,6 +27,7 @@ import { Campaign, DashboardService, DashboardParams } from '../dashboard.servic
         </ul>
         <hr />
         <prx-paging
+          class="paging"
           [currentPage]="currentPage$ | async"
           [totalPages]="totalPer | campaignListTotalPages"
           (showPage)="routeToParams({ page: $event })"

--- a/src/app/dashboard/filter/dashboard-filter.component.scss
+++ b/src/app/dashboard/filter/dashboard-filter.component.scss
@@ -1,3 +1,5 @@
+@import '~src/sass/variables';
+
 :host {
   ::ng-deep {
     .mat-form-field {
@@ -11,7 +13,7 @@
     .mat-form-field-outline:not(.mat-form-field-outline-thick) {
       .mat-form-field-outline-start,
       .mat-form-field-outline-end {
-        background-color: white
+        background-color: prx-theme-background(card);
       }
     }
   }
@@ -21,7 +23,7 @@ h1 {
   font-weight: 700;
   font-size: 1.75em;
   line-height: 2em;
-  color: #676767;
+  color: prx-theme-foreground(text);
   white-space: nowrap;
 }
 .dates {

--- a/src/app/dashboard/flight-table/flight-table.component.html
+++ b/src/app/dashboard/flight-table/flight-table.component.html
@@ -100,6 +100,7 @@
   </table>
 
   <mat-paginator
+    class="paginator"
     [length]="total"
     [pageSize]="routedParams?.per || 25"
     [pageIndex]="routedParams?.page - 1 || 0"

--- a/src/app/dashboard/flight-table/flight-table.component.scss
+++ b/src/app/dashboard/flight-table/flight-table.component.scss
@@ -23,11 +23,11 @@ $cell-padding: $cell-padding-v $cell-padding-h;
 }
 
 .mat-table-sticky:first-child {
-  border-right: 1px solid mat-color($prx-gray, 300);
+  border-right: 1px solid prx-theme-foreground(divider);
 }
 
 .mat-header-cell {
-  background: mat-color($prx-gray, 300);
+  background: prx-theme-background(table-header);
   border: white;
   padding: $cell-padding;
   line-height: $row-height;
@@ -44,11 +44,11 @@ $cell-padding: $cell-padding-v $cell-padding-h;
 }
 
 .mat-row:nth-child(even) {
-  background-color: white;
+  background-color: prx-theme-background(table-row);
 }
 
 .mat-row:nth-child(odd) {
-  background-color: mat-color($prx-gray, 100);
+  background-color: prx-theme-background(table-row-stripe);
 }
 
 .mat-cell {
@@ -81,4 +81,9 @@ $cell-padding: $cell-padding-v $cell-padding-h;
     background-color: $warn;
     color: $warn-contrast;
   }
+}
+
+.paginator {
+  position: sticky;
+  left: 0;
 }

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -1,3 +1,5 @@
+@import '~src/sass/variables';
+
 .login {
   width: 100%;
   max-width: 300px;
@@ -15,5 +17,5 @@ p {
   padding: 2px 8px;
 }
 p.error {
-  background: rgba(255, 0, 0, 0.2);
+  background: rgba($warn, 0.2);
 }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
-  styleUrls: ['login.component.css'],
+  styleUrls: ['login.component.scss'],
   template: `
     <div class="login">
       <h1>Login</h1>

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -10,7 +10,10 @@ $prx-accent: mat-palette($prx-orange, 500, 200, 800);
 $prx-success: mat-palette($prx-green);
 $prx-warn: mat-palette($prx-red);
 
+$prx-theme: mat-light-theme($prx-primary, $prx-accent, $prx-warn);
+
 // Define color variables.
+//// Theme colors
 $primary: mat-color($prx-primary);
 $primary-contrast: mat-color($prx-primary, default-contrast);
 $neutral: mat-color($prx-neutral);
@@ -21,3 +24,75 @@ $success: mat-color($prx-success);
 $success-contrast: mat-color($prx-success, default-contrast);
 $warn: mat-color($prx-warn);
 $warn-contrast: mat-color($prx-warn, default-contrast);
+
+//// Define theme functions.
+
+// Theme function to merge a few of our own theme props to Material's theme.
+//
+// See node_modules/@angular/material/_theming.scss for prop values provided
+// on background and foreground maps by default.
+@function prx-theme($theme: $prx-theme) {
+  // Default background props:
+  //    status-bar
+  //    app-bar
+  //    background
+  //    hover
+  //    card
+  //    dialog
+  //    disabled-button
+  //    raised-button
+  //    focused-button
+  //    selected-button
+  //    selected-disabled-button
+  //    disabled-button-toggle
+  //    unselected-chip
+  //    disabled-list-option
+  $background: map-get($theme, background);
+  // Default foreground props:
+  //    base
+  //    divider
+  //    dividers
+  //    disabled
+  //    disabled-button
+  //    disabled-text
+  //    elevation
+  //    hint-text
+  //    secondary-text
+  //    icon
+  //    icons
+  //    text
+  //    slider-min
+  //    slider-off
+  //    slider-off-active
+  $foreground: map-get($theme, foreground);
+
+  @return (
+    background: map-merge($background, (
+      app-area: mat-color($background, card),
+      tab: mat-color($background, hover),
+      selected-tab: mat-color($background, card),
+      table-header: mat-color($background, status-bar),
+      table-row: mat-color($background, card),
+      table-row-stripe: mat-color($background, app-bar)
+    )),
+    foreground: map-merge($foreground, (
+      tab: $primary,
+      selected-tab: $primary,
+      link: $primary
+    ))
+  )
+};
+
+// Helper function to simplify getting theme background values.
+@function prx-theme-background($prop) {
+  $background: map-get(prx-theme(), background);
+
+  @return map-get($background, $prop);
+};
+
+// Helper function to simplify getting theme forground values.
+@function prx-theme-foreground($prop) {
+  $foreground: map-get(prx-theme(), foreground);
+
+  @return map-get($foreground, $prop);
+};

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -66,7 +66,7 @@ $warn-contrast: mat-color($prx-warn, default-contrast);
   //    slider-off-active
   $foreground: map-get($theme, foreground);
 
-  @return (
+  @return map-merge($theme, (
     background: map-merge($background, (
       app-area: mat-color($background, card),
       tab: mat-color($background, hover),
@@ -80,19 +80,19 @@ $warn-contrast: mat-color($prx-warn, default-contrast);
       selected-tab: $primary,
       link: $primary
     ))
-  )
+  ));
 };
 
 // Helper function to simplify getting theme background values.
-@function prx-theme-background($prop) {
+@function prx-theme-background($prop, $opacity: null) {
   $background: map-get(prx-theme(), background);
 
-  @return map-get($background, $prop);
+  @return mat-color($background, $prop, $opacity);
 };
 
 // Helper function to simplify getting theme forground values.
-@function prx-theme-foreground($prop) {
+@function prx-theme-foreground($prop, $opacity: null) {
   $foreground: map-get(prx-theme(), foreground);
 
-  @return map-get($foreground, $prop);
+  @return mat-color($foreground, $prop, $opacity);
 };

--- a/src/sass/prx-theme.scss
+++ b/src/sass/prx-theme.scss
@@ -2,6 +2,4 @@
 
 @include mat-core();
 
-$prx: mat-light-theme($prx-primary, $prx-accent, $prx-warn);
-
-@include angular-material-theme($prx);
+@include angular-material-theme($prx-theme);


### PR DESCRIPTION
- add sass functions for theming
- replace static colors with theme variables or theme map prop
- adjustment made to campaign form layout
- flight table paginator should not scroll with overflowed cells

### To Review

- [ ] Checkout branch.
- [ ] Run `yarn`.
- [ ] Run `docker-compose build`.
- [ ] Run `docker-compose up`.
- [ ] Start `http-proxy`.
- [ ] Go to [grove.prx.docker](https://grove.prx.docker).
- [ ] Ensure theme coloring is as expected.
- [ ] Edit `/sass/_variables.scss` and change the function used on line 13 to `mat-dark-theme`.
- [ ] Ensure dark theme is applied as expected (this is to demonstrate the theme variables are wired up correctly.)
- [ ] Go to Flights table and adjust screen so the table can scroll horizontally.
- [ ] Ensure paginator stays in place as you scroll the table.
- [ ] Go to a campaign and note the fields layout with horizontal space between fields when they are in two columns.