### PR TITLE
fixes sort flights by createdAt after form update

### DIFF
--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -2,7 +2,7 @@ import { MockHalDoc } from 'ngx-prx-styleguide';
 import * as actions from '../actions';
 import { campaignDocFixture, flightFixture, flightDocFixture, createFlightsState } from '../models/campaign-state.factory';
 import { reducer, initialState, selectAll, selectEntities, selectIds } from './flight.reducer';
-import { docToFlight } from '../models';
+import { docToFlight, Flight } from '../models';
 
 describe('Flight Reducer', () => {
   describe('unknown action', () => {
@@ -70,6 +70,25 @@ describe('Flight Reducer', () => {
     const flight = selectEntities(result)[flightFixture.id];
     expect(flight.localFlight.name).toBe('This is a flight name');
     expect(flight.remoteFlight.name).toBe(flightFixture.name);
+  });
+
+  it('should retain flight values not in the form update', () => {
+    let result = reducer(
+      initialState,
+      new actions.CampaignLoadSuccess({ campaignDoc: new MockHalDoc(campaignDocFixture), flightDocs: [new MockHalDoc(flightDocFixture)] })
+    );
+    result = reducer(
+      result,
+      new actions.CampaignFlightFormUpdate({
+        // update only contains name
+        flight: { id: flightFixture.id, name: 'This is a flight name' } as Flight,
+        changed: true,
+        valid: true
+      })
+    );
+    const flight = selectEntities(result)[flightFixture.id];
+    expect(flight.localFlight.name).toBe('This is a flight name');
+    expect(flight.localFlight.set_inventory_uri).toBe(flightFixture.set_inventory_uri);
   });
 
   it('should set the goal', () => {

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -66,8 +66,19 @@ export function reducer(state = initialState, action: CampaignActions): State {
       return adapter.updateOne({ id, changes: { softDeleted } }, state);
     }
     case ActionTypes.CAMPAIGN_FLIGHT_FORM_UPDATE: {
-      const { flight: localFlight, changed, valid } = action.payload;
-      return adapter.updateOne({ id: localFlight.id, changes: { localFlight, changed, valid } }, state);
+      const { flight, changed, valid } = action.payload;
+      const localFlight = { ...(state.entities[flight.id] && state.entities[flight.id].localFlight), ...flight };
+      return adapter.updateOne(
+        {
+          id: flight.id,
+          changes: {
+            localFlight,
+            changed,
+            valid
+          }
+        },
+        state
+      );
     }
     case ActionTypes.CAMPAIGN_FLIGHT_SET_GOAL: {
       const { flightId: id, totalGoal, dailyMinimum, valid } = action.payload;


### PR DESCRIPTION
The flight tabs are sorted by the localFlight.createdAt property. The createAt property doesnt exist in the form so it was getting cleared out of the localFlight on update (could've swore I looked at this earlier and thought it was good, 🤷‍♀ fixed now).