### PR TITLE
82: Add actual/goal to campaign cards

### DIFF
--- a/src/app/dashboard/campaign-card/campaign-card-abbreviate-number.pipe.spec.ts
+++ b/src/app/dashboard/campaign-card/campaign-card-abbreviate-number.pipe.spec.ts
@@ -1,0 +1,14 @@
+import { CampaignCardAbbreviateNumberPipe } from './campaign-card-abbreviate-number.pipe';
+import { flights } from '../dashboard.service.mock';
+
+describe('CampaignCardAbbreviateNumberPipe', () => {
+  const pipe = new CampaignCardAbbreviateNumberPipe();
+  it('should format without suffix', () => {
+    expect(pipe.transform(67)).toMatch('67');
+  });
+  it('should format with suffix', () => {
+    expect(pipe.transform(3000)).toMatch('3K');
+    expect(pipe.transform(3000000)).toMatch('3M');
+    expect(pipe.transform(3000000000)).toMatch('3B');
+  });
+});

--- a/src/app/dashboard/campaign-card/campaign-card-abbreviate-number.pipe.ts
+++ b/src/app/dashboard/campaign-card/campaign-card-abbreviate-number.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'campaignCardAbbrevNumber'
+})
+export class CampaignCardAbbreviateNumberPipe implements PipeTransform {
+  transform(value: number): string {
+    if (value < 1000) {
+      return `${value}`;
+    }
+
+    const suffixes = ['K', 'M', 'B'];
+    const pow = Math.floor((`${Math.round(value)}`.length - 1) / 3);
+    const val = Math.round(value / Math.pow(1000, pow));
+    const suffix = suffixes[pow - 1];
+
+    return `${val}${suffix}`;
+  }
+}

--- a/src/app/dashboard/campaign-card/campaign-card.component.scss
+++ b/src/app/dashboard/campaign-card/campaign-card.component.scss
@@ -1,17 +1,74 @@
 @import '~src/sass/variables';
-@import '~src/sass/status';
 
 :host {
   display: block;
+  height: 100%;
   background-color: prx-theme-background(card);
   color: prx-theme-foreground(text);
 }
-.header {
-  height: 3px;
-}
 section {
-  padding: 10px;
-  min-height: 92px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-top: 3px solid transparent;
+
+  header {
+    padding: 10px 10px 0 10px;
+  }
+
+  .content {
+    flex-grow: 1;
+    padding: 10px;
+  }
+
+  footer {
+    position: relative;
+    padding: 1rem;
+    border-top: 1px solid prx-theme-foreground(divider);
+
+    text-align: center;
+
+    & > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    .progress {
+      font-size: 1.3rem;
+      letter-spacing: 0.05rem;
+    }
+
+    .progress-ind {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 0;
+      background-color: mat-color($prx-green-palette, default);
+      opacity: 0.1;
+    }
+  }
+
+  &.draft {
+    border-color: mat-color($prx-blue-palette, lighter);
+  }
+  &.ok,
+  &.approved {
+    border-color: mat-color($prx-green-palette, default);
+  }
+  &.paused {
+    border-color: mat-color($prx-yellow-palette, default);
+  }
+  &.error,
+  &.canceled {
+    border-color: mat-color($prx-red-palette, default);
+  }
+  &.hold {
+    border-color: mat-color($prx-orange-palette, default);
+  }
+  &.sold {
+    border-color: mat-color($prx-aqua-palette, default);
+  }
 }
 section.loading {
   position: relative;

--- a/src/app/dashboard/campaign-card/campaign-card.component.spec.ts
+++ b/src/app/dashboard/campaign-card/campaign-card.component.spec.ts
@@ -6,7 +6,13 @@ import { By } from '@angular/platform-browser';
 import { SharedModule } from '../../shared/shared.module';
 
 import { campaigns as campaignsFixture } from '../dashboard.service.mock';
-import { CampaignCardComponent, CampaignFlightDatesPipe, CampaignFlightTargetsPipe, CampaignFlightZonesPipe } from '.';
+import {
+  CampaignCardComponent,
+  CampaignCardAbbreviateNumberPipe,
+  CampaignFlightDatesPipe,
+  CampaignFlightTargetsPipe,
+  CampaignFlightZonesPipe
+} from '.';
 
 describe('CampaignCardComponent', () => {
   let comp: CampaignCardComponent;
@@ -17,7 +23,13 @@ describe('CampaignCardComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, SharedModule],
-      declarations: [CampaignCardComponent, CampaignFlightDatesPipe, CampaignFlightTargetsPipe, CampaignFlightZonesPipe]
+      declarations: [
+        CampaignCardComponent,
+        CampaignCardAbbreviateNumberPipe,
+        CampaignFlightDatesPipe,
+        CampaignFlightTargetsPipe,
+        CampaignFlightZonesPipe
+      ]
     })
       .compileComponents()
       .then(() => {
@@ -39,5 +51,17 @@ describe('CampaignCardComponent', () => {
 
   it('should show campaign status', () => {
     expect(de.query(By.css('span.status')).nativeElement.textContent.toLowerCase()).toMatch(comp.campaign.status);
+  });
+
+  it('should return formatted campaign progress percentage', () => {
+    comp.campaign = campaignsFixture[0];
+    fix.detectChanges();
+    expect(comp.progressPercent).toBe('10%');
+    comp.campaign = campaignsFixture[1];
+    fix.detectChanges();
+    expect(comp.progressPercent).toBe('60%');
+    comp.campaign = campaignsFixture[2];
+    fix.detectChanges();
+    expect(comp.progressPercent).toBe('100%');
   });
 });

--- a/src/app/dashboard/campaign-card/campaign-card.component.ts
+++ b/src/app/dashboard/campaign-card/campaign-card.component.ts
@@ -4,23 +4,29 @@ import { Campaign } from '../dashboard.service';
 @Component({
   selector: 'grove-campaign-card',
   template: `
-    <div class="header {{ campaign?.status }}"></div>
-    <section *ngIf="campaign">
-      <div>{{ campaign.flights | campaignFlightDates }}</div>
-      <h3>
-        <a routerLink="{{ '/campaign/' + campaign.id }}">
-          {{ campaign.advertiser && campaign.advertiser.label }}
-        </a>
-      </h3>
-      <div>
-        <span class="status {{ campaign.status }}">{{ campaign.status | titlecase }}</span>
-        {{ campaign.type | titlecase }}
+    <section class="{{ campaign?.status }}" *ngIf="campaign">
+      <header>{{ campaign.flights | campaignFlightDates }}</header>
+      <div class="content">
+        <h3>
+          <a routerLink="{{ '/campaign/' + campaign.id }}">
+            {{ campaign.advertiser && campaign.advertiser.label }}
+          </a>
+        </h3>
+        <div>
+          <span class="status {{ campaign.status }}">{{ campaign.status | titlecase }}</span>
+          {{ campaign.type | titlecase }}
+        </div>
+        <div *ngIf="campaign.flights | campaignFlightTargets as targets">
+          <prx-icon size="1em" name="globe-americas"></prx-icon>
+          {{ targets }}
+        </div>
+        <div>{{ campaign.flights | campaignFlightZones }}</div>
       </div>
-      <div *ngIf="campaign.flights | campaignFlightTargets as targets">
-        <prx-icon size="1em" name="globe-americas"></prx-icon>
-        {{ targets }}
-      </div>
-      <div>{{ campaign.flights | campaignFlightZones }}</div>
+      <footer>
+        <div class="progress-ind" [style.width]="progressPercent"></div>
+        <p class="progress">{{ campaign.actualCount | largeNumber }} / {{ campaign.totalGoal | campaignCardAbbrevNumber }}</p>
+        <p>Inventory Served</p>
+      </footer>
     </section>
     <section class="loading" *ngIf="!campaign">
       <prx-spinner></prx-spinner>
@@ -31,4 +37,8 @@ import { Campaign } from '../dashboard.service';
 })
 export class CampaignCardComponent {
   @Input() campaign: Campaign;
+
+  get progressPercent() {
+    return Math.min(1, this.campaign.actualCount / this.campaign.totalGoal) * 100 + '%';
+  }
 }

--- a/src/app/dashboard/campaign-card/index.ts
+++ b/src/app/dashboard/campaign-card/index.ts
@@ -1,4 +1,5 @@
 export * from './campaign-card.component';
+export * from './campaign-card-abbreviate-number.pipe';
 export * from './campaign-flight-dates.pipe';
 export * from './campaign-flight-targets.pipe';
 export * from './campaign-flight-zones.pipe';

--- a/src/app/dashboard/campaign-list/campaign-list.component.scss
+++ b/src/app/dashboard/campaign-list/campaign-list.component.scss
@@ -2,13 +2,9 @@
 
 ul {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   grid-auto-rows: 1fr;
   grid-gap: 20px;
-}
-
-grove-campaign-card {
-  height: 100%;
 }
 
 prx-paging {
@@ -36,16 +32,4 @@ prx-paging {
   text-align: center;
   color: prx-theme-foreground(text);
   font-style: italic;
-}
-
-@media (min-width: 768px) {
-  ul {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (min-width: 1024px) {
-  ul {
-    grid-template-columns: repeat(4, 1fr);
-  }
 }

--- a/src/app/dashboard/campaign-list/campaign-list.component.spec.ts
+++ b/src/app/dashboard/campaign-list/campaign-list.component.spec.ts
@@ -12,7 +12,13 @@ import { SharedModule } from '../../shared/shared.module';
 import { DashboardService } from '../dashboard.service';
 import { DashboardServiceMock, campaigns as campaignsFixture } from '../dashboard.service.mock';
 import { CampaignListComponent, CampaignListTotalPagesPipe } from './';
-import { CampaignCardComponent, CampaignFlightDatesPipe, CampaignFlightTargetsPipe, CampaignFlightZonesPipe } from '../campaign-card';
+import {
+  CampaignCardComponent,
+  CampaignCardAbbreviateNumberPipe,
+  CampaignFlightDatesPipe,
+  CampaignFlightTargetsPipe,
+  CampaignFlightZonesPipe
+} from '../campaign-card';
 
 describe('CampaignListComponent', () => {
   let comp: CampaignListComponent;
@@ -29,6 +35,7 @@ describe('CampaignListComponent', () => {
       imports: [RouterTestingModule, MatProgressSpinnerModule, NoopAnimationsModule, PagingModule, SharedModule],
       declarations: [
         CampaignCardComponent,
+        CampaignCardAbbreviateNumberPipe,
         CampaignFlightDatesPipe,
         CampaignFlightTargetsPipe,
         CampaignFlightZonesPipe,

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -15,7 +15,13 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { SharedModule } from '../shared/shared.module';
 import { PagingModule } from 'ngx-prx-styleguide';
 
-import { CampaignCardComponent, CampaignFlightDatesPipe, CampaignFlightTargetsPipe, CampaignFlightZonesPipe } from './campaign-card';
+import {
+  CampaignCardComponent,
+  CampaignFlightDatesPipe,
+  CampaignFlightTargetsPipe,
+  CampaignFlightZonesPipe,
+  CampaignCardAbbreviateNumberPipe
+} from './campaign-card';
 
 import { DashboardComponent } from './dashboard.component';
 import { dashboardRouting } from './dashboard.routing';
@@ -32,6 +38,7 @@ import { FlightTableContainerComponent, FlightTableComponent } from './flight-ta
     FilterDateComponent,
     CampaignListComponent,
     CampaignCardComponent,
+    CampaignCardAbbreviateNumberPipe,
     CampaignFlightDatesPipe,
     CampaignFlightTargetsPipe,
     CampaignFlightZonesPipe,

--- a/src/app/dashboard/dashboard.service.mock.ts
+++ b/src/app/dashboard/dashboard.service.mock.ts
@@ -48,7 +48,9 @@ export const campaigns: Campaign[] = [
     repName: 'John',
     notes: '',
     flights,
-    loading: false
+    loading: false,
+    actualCount: 10000,
+    totalGoal: 100000
   },
   {
     id: 2,
@@ -60,7 +62,9 @@ export const campaigns: Campaign[] = [
     repName: 'Jacob',
     notes: '',
     flights,
-    loading: false
+    loading: false,
+    actualCount: 60000,
+    totalGoal: 100000
   },
   {
     id: 3,
@@ -72,7 +76,9 @@ export const campaigns: Campaign[] = [
     repName: 'Jingleheimer',
     notes: '',
     flights,
-    loading: false
+    loading: false,
+    actualCount: 125000,
+    totalGoal: 100000
   }
 ];
 

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -76,6 +76,8 @@ export interface Campaign {
   notes: string;
   flights?: Flight[];
   loading?: boolean;
+  totalGoal?: number;
+  actualCount?: number;
 }
 
 @Injectable({
@@ -165,15 +167,11 @@ export class DashboardService {
   }
 
   get actualsTotal(): Observable<number> {
-    return this.flights.pipe(
-      map((flights: Flight[]) => flights.reduce((acc, { actualCount }: Flight) => acc + actualCount, 0))
-    );
+    return this.flights.pipe(map((flights: Flight[]) => flights.reduce((acc, { actualCount }: Flight) => acc + actualCount, 0)));
   }
 
   get goalsTotal(): Observable<number> {
-    return this.flights.pipe(
-      map((flights: Flight[]) => flights.reduce((acc, { totalGoal }: Flight) => acc + totalGoal, 0))
-    );
+    return this.flights.pipe(map((flights: Flight[]) => flights.reduce((acc, { totalGoal }: Flight) => acc + totalGoal, 0)));
   }
 
   get campaignFacets(): Observable<Facets> {
@@ -226,6 +224,8 @@ export class DashboardService {
             status: campaignDoc['status'],
             repName: campaignDoc['repName'],
             notes: campaignDoc['notes'],
+            actualCount: campaignDoc['actualCount'],
+            totalGoal: campaignDoc['totalGoal'],
             loading: false,
             advertiser: { id: advertiserDoc['id'], label: advertiserDoc['name'] },
             flights: flightDocs.map(doc => ({


### PR DESCRIPTION
Closes #82 

Campaign card footers should now have actual counts compared to total goal, with a nice progress bar in the background.