### PR TITLE
duplicate campaign

### DIFF
--- a/src/app/campaign/nav/campaign-nav.component.scss
+++ b/src/app/campaign/nav/campaign-nav.component.scss
@@ -41,17 +41,16 @@
   }
 }
 
-.add-flight {
+.secondary-link {
   transition: background-color 100ms linear 0ms;
   display: grid;
   grid-template-columns: min-content auto;
   grid-column-gap: 0.25rem;
-  justify-content: center;
+  justify-content: start;
   align-items: center;
   margin: 0.5rem;
   padding: 0.5rem;
   border: 1px dashed prx-theme-foreground(divider);
-  text-align: center;
 
   &:hover {
     background-color: prx-theme-background(selected-tab);

--- a/src/app/campaign/nav/campaign-nav.component.scss
+++ b/src/app/campaign/nav/campaign-nav.component.scss
@@ -55,4 +55,7 @@
   &:hover {
     background-color: prx-theme-background(selected-tab);
   }
+  &.disabled {
+    color: prx-theme-foreground(disabled);
+  }
 }

--- a/src/app/campaign/nav/campaign-nav.component.ts
+++ b/src/app/campaign/nav/campaign-nav.component.ts
@@ -22,7 +22,12 @@ import { Campaign, Flight, FlightState } from '../store/models';
       </a>
     </mat-nav-list>
     <a class="secondary-link" routerLink="" (click)="createFlight.emit()"><mat-icon>add</mat-icon> Add a Flight</a>
-    <a class="secondary-link" routerLink="/campaign/new" [state]="dupCampaignState"><mat-icon>file_copy</mat-icon>Duplicate Campaign</a>
+    <ng-container *ngIf="valid && !changed && !isSaving; else disabledDuplicate">
+      <a class="secondary-link" routerLink="/campaign/new" [state]="dupCampaignState"><mat-icon>file_copy</mat-icon>Duplicate Campaign</a>
+    </ng-container>
+    <ng-template #disabledDuplicate>
+      <a class="secondary-link disabled"><mat-icon>file_copy</mat-icon>Duplicate Campaign</a>
+    </ng-template>
   `,
   styleUrls: ['./campaign-nav.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/campaign/nav/campaign-nav.component.ts
+++ b/src/app/campaign/nav/campaign-nav.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
-import { FlightState } from '../store/models';
+import { Campaign, Flight, FlightState } from '../store/models';
 
 @Component({
   selector: 'grove-campaign-nav',
@@ -21,16 +21,28 @@ import { FlightState } from '../store/models';
         <mat-icon color="warn" *ngIf="!statusOk(flight)">priority_high</mat-icon>
       </a>
     </mat-nav-list>
-    <a class="add-flight" [routerLink]="" (click)="createFlight.emit()"><mat-icon>add</mat-icon> Add a Flight</a>
+    <a class="secondary-link" routerLink="" (click)="createFlight.emit()"><mat-icon>add</mat-icon> Add a Flight</a>
+    <a class="secondary-link" routerLink="/campaign/new" [state]="dupCampaignState"><mat-icon>file_copy</mat-icon>Duplicate Campaign</a>
   `,
   styleUrls: ['./campaign-nav.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CampaignNavComponent {
+  @Input() campaign: Campaign;
   @Input() flights: FlightState[];
+  @Input() valid: boolean;
+  @Input() changed: boolean;
+  @Input() isSaving: boolean;
   @Output() createFlight = new EventEmitter();
 
   statusOk(flight: FlightState): boolean {
     return !flight.localFlight.status || flight.localFlight.status === 'ok';
+  }
+
+  get dupCampaignState(): { campaign: Campaign; flights: Flight[] } {
+    return {
+      campaign: this.campaign,
+      flights: this.flights.filter(flight => !flight.softDeleted).map(flight => flight.localFlight)
+    };
   }
 }

--- a/src/app/campaign/store/actions/action.types.ts
+++ b/src/app/campaign/store/actions/action.types.ts
@@ -1,7 +1,6 @@
 export enum ActionTypes {
   CAMPAIGN_NEW = '[Campaign] Campaign New',
   CAMPAIGN_DUP_FROM_FORM = '[Campaign] Campaign Dup From Form',
-  CAMPAIGN_DUP = '[Campaign] Campaign Dup',
   CAMPAIGN_DUP_BY_ID = '[Campaign] Campaign Dup By Id',
   CAMPAIGN_DUP_BY_ID_SUCCESS = '[Campaign] Campaign Dup By Id Success',
   CAMPAIGN_DUP_BY_ID_FAILURE = '[Campaign] Campaign Dup By Id Failure',

--- a/src/app/campaign/store/actions/action.types.ts
+++ b/src/app/campaign/store/actions/action.types.ts
@@ -1,5 +1,10 @@
 export enum ActionTypes {
   CAMPAIGN_NEW = '[Campaign] Campaign New',
+  CAMPAIGN_DUP_FROM_FORM = '[Campaign] Campaign Dup From Form',
+  CAMPAIGN_DUP = '[Campaign] Campaign Dup',
+  CAMPAIGN_DUP_BY_ID = '[Campaign] Campaign Dup By Id',
+  CAMPAIGN_DUP_BY_ID_SUCCESS = '[Campaign] Campaign Dup By Id Success',
+  CAMPAIGN_DUP_BY_ID_FAILURE = '[Campaign] Campaign Dup By Id Failure',
   CAMPAIGN_LOAD = '[Campaign] Campaign Load',
   CAMPAIGN_LOAD_SUCCESS = '[Campaign] Campaign Load Success',
   CAMPAIGN_LOAD_FAILURE = '[Campaign] Campaign Load Failure',

--- a/src/app/campaign/store/actions/campaign-action.creator.ts
+++ b/src/app/campaign/store/actions/campaign-action.creator.ts
@@ -5,6 +5,36 @@ import { HalDoc } from 'ngx-prx-styleguide';
 
 export class CampaignNew implements Action {
   readonly type = ActionTypes.CAMPAIGN_NEW;
+
+  constructor(public payload: {}) {}
+}
+
+export class CampaignDupFromForm implements Action {
+  readonly type = ActionTypes.CAMPAIGN_DUP_FROM_FORM;
+
+  constructor(public payload: { campaign: Campaign; flights: Flight[]; timestamp?: number }) {
+    this.payload.timestamp = payload.timestamp || Date.now();
+  }
+}
+
+export class CampaignDupById implements Action {
+  readonly type = ActionTypes.CAMPAIGN_DUP_BY_ID;
+
+  constructor(public payload: { id: number }) {}
+}
+
+export class CampaignDupByIdSuccess implements Action {
+  readonly type = ActionTypes.CAMPAIGN_DUP_BY_ID_SUCCESS;
+
+  constructor(public payload: { campaignDoc: HalDoc; flightDocs: HalDoc[]; timestamp?: number }) {
+    this.payload.timestamp = payload.timestamp || Date.now();
+  }
+}
+
+export class CampaignDupByIdFailure implements Action {
+  readonly type = ActionTypes.CAMPAIGN_DUP_BY_ID_FAILURE;
+
+  constructor(public payload: { error: any }) {}
 }
 
 export class CampaignLoad implements Action {
@@ -96,6 +126,10 @@ export class CampaignFlightSetGoal implements Action {
 
 export type CampaignActions =
   | CampaignNew
+  | CampaignDupFromForm
+  | CampaignDupById
+  | CampaignDupByIdSuccess
+  | CampaignDupByIdFailure
   | CampaignLoad
   | CampaignLoadSuccess
   | CampaignLoadFailure

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
+import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { Subscription } from 'rxjs';
 import { first, filter } from 'rxjs/operators';
@@ -161,8 +162,8 @@ export class CampaignActionService implements OnDestroy {
   saveCampaignAndFlights() {
     this.store
       .pipe(select(selectCampaignWithFlightsForSave), first())
-      .subscribe(({ campaign, updatedFlights, createdFlights, deletedFlights }) =>
-        this.store.dispatch(new campaignActions.CampaignSave({ campaign, updatedFlights, createdFlights, deletedFlights }))
+      .subscribe(({ campaign, campaignDoc, updatedFlights, createdFlights, deletedFlights }) =>
+        this.store.dispatch(new campaignActions.CampaignSave({ campaign, campaignDoc, updatedFlights, createdFlights, deletedFlights }))
       );
   }
 }

--- a/src/app/campaign/store/effects/campaign.effects.ts
+++ b/src/app/campaign/store/effects/campaign.effects.ts
@@ -6,7 +6,7 @@ import { map, mergeMap, catchError, tap } from 'rxjs/operators';
 import { HalDoc, ToastrService } from 'ngx-prx-styleguide';
 import * as campaignActions from '../actions/campaign-action.creator';
 import { ActionTypes } from '../actions/action.types';
-import { CampaignFormSave } from '../models';
+import { CampaignFormSave, Flight } from '../models';
 import { CampaignService } from '../../../core';
 
 @Injectable()
@@ -27,7 +27,7 @@ export class CampaignEffects {
     mergeMap((payload: CampaignFormSave) => {
       let campaignSaveResult: Observable<HalDoc>;
       if (payload.campaign.id) {
-        campaignSaveResult = this.campaignService.updateCampaign(payload.campaign);
+        campaignSaveResult = this.campaignService.updateCampaign(payload.campaignDoc, payload.campaign);
       } else {
         campaignSaveResult = this.campaignService.createCampaign(payload.campaign);
       }
@@ -61,7 +61,7 @@ export class CampaignEffects {
             deletedFlightDocs: { [id: number]: HalDoc };
           }) => {
             const createdFlights: { [id: number]: Observable<HalDoc> } = payload.createdFlights.reduce(
-              (acc, flight) => ({ ...acc, [flight.id]: this.campaignService.createFlight(flight) }),
+              (acc, flight) => ({ ...acc, [flight.id]: this.campaignService.createFlight(campaignDoc, flight) }),
               {}
             );
             return payload.createdFlights.length
@@ -139,6 +139,15 @@ export class CampaignEffects {
       this.router.navigate(['/campaign', campaignId, 'flight', flightId]);
       return new campaignActions.CampaignDupFlightWithTempId({ flightId, flight });
     })
+  );
+
+  @Effect()
+  dupCampaignById$ = this.actions$.pipe(
+    ofType(ActionTypes.CAMPAIGN_DUP_BY_ID),
+    map((action: campaignActions.CampaignDupById) => action.payload),
+    mergeMap(payload => this.campaignService.loadCampaignZoomFlights(payload.id)),
+    map(({ campaignDoc, flightDocs }) => new campaignActions.CampaignDupByIdSuccess({ campaignDoc, flightDocs })),
+    catchError(error => of(new campaignActions.CampaignDupByIdFailure({ error })))
   );
 
   constructor(private actions$: Actions, private campaignService: CampaignService, private router: Router, private toastr: ToastrService) {}

--- a/src/app/campaign/store/effects/campaign.effects.ts
+++ b/src/app/campaign/store/effects/campaign.effects.ts
@@ -147,7 +147,14 @@ export class CampaignEffects {
     map((action: campaignActions.CampaignDupById) => action.payload),
     mergeMap(payload => this.campaignService.loadCampaignZoomFlights(payload.id)),
     map(({ campaignDoc, flightDocs }) => new campaignActions.CampaignDupByIdSuccess({ campaignDoc, flightDocs })),
+    tap(() => this.toastr.success('Campaign duplicated')),
     catchError(error => of(new campaignActions.CampaignDupByIdFailure({ error })))
+  );
+
+  @Effect({ dispatch: false })
+  dupCampaignFromForm$ = this.actions$.pipe(
+    ofType(ActionTypes.CAMPAIGN_DUP_FROM_FORM),
+    tap(() => this.toastr.success('Campaign duplicated'))
   );
 
   constructor(private actions$: Actions, private campaignService: CampaignService, private router: Router, private toastr: ToastrService) {}

--- a/src/app/campaign/store/models/campaign.models.ts
+++ b/src/app/campaign/store/models/campaign.models.ts
@@ -32,3 +32,10 @@ export const docToCampaign = (doc: HalDoc): Campaign => {
   campaign.set_account_uri = doc.expand('prx:account');
   return campaign;
 };
+
+export const duplicateCampaign = (campaign: Campaign): Campaign => {
+  // remove id from dup campaign and set to Draft
+  const { id, ...dupCampaign } = campaign;
+  campaign.status = 'draft';
+  return dupCampaign;
+};

--- a/src/app/campaign/store/models/combined.models.ts
+++ b/src/app/campaign/store/models/combined.models.ts
@@ -1,8 +1,10 @@
+import { HalDoc } from 'ngx-prx-styleguide';
 import { Campaign } from './campaign.models';
 import { Flight } from './flight.models';
 
 export interface CampaignFormSave {
   campaign: Campaign;
+  campaignDoc: HalDoc;
   updatedFlights: Flight[];
   createdFlights: Flight[];
   deletedFlights: Flight[];

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -45,3 +45,10 @@ export const docToFlight = (doc: HalDoc): Flight => {
 export const getFlightZoneIds = (zones: any[]): string[] => {
   return zones.filter(z => z).map(z => z.id || z);
 };
+
+export const duplicateFlight = (flight: Flight, tempId: number): Flight => {
+  // remove createdAt, startAt, endAt and set temp id
+  const { createdAt, startAt, endAt, ...dupFlight } = flight;
+  dupFlight.id = tempId;
+  return dupFlight as Flight;
+};

--- a/src/app/campaign/store/reducers/campaign.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/campaign.reducer.spec.ts
@@ -22,7 +22,7 @@ describe('Campaign Reducer', () => {
   });
 
   it('should setup for a new campaign', () => {
-    const result = reducer(createCampaignState().campaign, new campaignActions.CampaignNew());
+    const result = reducer(createCampaignState().campaign, new campaignActions.CampaignNew({}));
     expect(result).toMatchObject({ ...initialState, loaded: true, loading: false });
   });
 
@@ -49,7 +49,7 @@ describe('Campaign Reducer', () => {
   });
 
   it('should set campaign loading', () => {
-    const newResult = reducer(initialState, new campaignActions.CampaignNew());
+    const newResult = reducer(initialState, new campaignActions.CampaignNew({}));
     expect(newResult.loading).toBe(false);
 
     let loadResult = reducer(initialState, new advertiserActions.AdvertisersLoad({}));
@@ -104,6 +104,7 @@ describe('Campaign Reducer', () => {
       initialState,
       new campaignActions.CampaignSave({
         campaign: campaignFixture,
+        campaignDoc: new MockHalDoc(campaignDocFixture),
         deletedFlights: [],
         updatedFlights: [flightFixture],
         createdFlights: []
@@ -124,7 +125,7 @@ describe('Campaign Reducer', () => {
     expect(result.saving).toBe(false);
   });
 
-  it('should set campaign from campaign form save success', () => {
+  it('should set campaign state from campaign form save success', () => {
     const result = reducer(
       initialState,
       new campaignActions.CampaignSaveSuccess({
@@ -150,5 +151,32 @@ describe('Campaign Reducer', () => {
       })
     );
     expect(result.localCampaign.set_advertiser_uri).toBe('/some/uri');
+  });
+
+  it('should set campaign state for campaign duplicated from form', () => {
+    let result = reducer(
+      initialState,
+      new campaignActions.CampaignLoadSuccess({
+        campaignDoc: new MockHalDoc(campaignDocFixture),
+        flightDocs: [new MockHalDoc(flightDocFixture)]
+      })
+    );
+    result = reducer(result, new campaignActions.CampaignDupFromForm({ campaign: campaignFixture, flights: [flightFixture] }));
+    expect(result.localCampaign).not.toMatchObject(campaignFixture);
+    expect(result.localCampaign.id).toBeUndefined();
+    expect(result.localCampaign.name).toEqual(campaignFixture.name);
+  });
+
+  it('should set campaign state for campaign duplicated by id', () => {
+    const result = reducer(
+      initialState,
+      new campaignActions.CampaignDupByIdSuccess({
+        campaignDoc: new MockHalDoc(campaignDocFixture),
+        flightDocs: [new MockHalDoc(flightDocFixture)]
+      })
+    );
+    expect(result.localCampaign).not.toMatchObject(campaignFixture);
+    expect(result.localCampaign.id).toBeUndefined();
+    expect(result.localCampaign.name).toEqual(campaignFixture.name);
   });
 });

--- a/src/app/campaign/store/reducers/campaign.reducer.ts
+++ b/src/app/campaign/store/reducers/campaign.reducer.ts
@@ -2,7 +2,7 @@ import { ActionTypes } from '../actions/action.types';
 import { AdvertiserActions } from '../actions/advertiser-action.creator';
 import { CampaignActions } from '../actions/campaign-action.creator';
 import { docToAdvertiser } from '../models/advertiser.models';
-import { CampaignState, docToCampaign } from '../models/campaign.models';
+import { CampaignState, docToCampaign, duplicateCampaign } from '../models/campaign.models';
 
 export const initialState: CampaignState = {
   localCampaign: {
@@ -25,6 +25,26 @@ export function reducer(state = initialState, action: CampaignActions | Advertis
   switch (action.type) {
     case ActionTypes.CAMPAIGN_NEW: {
       return { ...initialState, loading: false, loaded: true };
+    }
+    case ActionTypes.CAMPAIGN_DUP_FROM_FORM: {
+      return {
+        localCampaign: duplicateCampaign(action.payload.campaign),
+        changed: true,
+        valid: true,
+        loading: false,
+        loaded: true,
+        saving: false
+      };
+    }
+    case ActionTypes.CAMPAIGN_DUP_BY_ID_SUCCESS: {
+      return {
+        localCampaign: duplicateCampaign(docToCampaign(action.payload.campaignDoc)),
+        changed: true,
+        valid: true,
+        loading: false,
+        loaded: true,
+        saving: false
+      };
     }
     case ActionTypes.CAMPAIGN_FORM_UPDATE: {
       const { campaign, changed, valid } = action.payload;
@@ -82,9 +102,10 @@ export function reducer(state = initialState, action: CampaignActions | Advertis
       }
       return state;
     }
+    case ActionTypes.CAMPAIGN_DUP_BY_ID_FAILURE:
     case ActionTypes.CAMPAIGN_LOAD_FAILURE: {
       return {
-        ...state,
+        ...initialState,
         loading: false,
         loaded: true,
         error: action.payload.error

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -1,7 +1,7 @@
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import { ActionTypes } from '../actions/action.types';
 import { CampaignActions } from '../actions/campaign-action.creator';
-import { docToFlight, Flight, FlightState } from '../models';
+import { docToFlight, Flight, FlightState, duplicateFlight } from '../models';
 
 export interface State extends EntityState<FlightState> {
   // additional entities state properties for the collection
@@ -18,6 +18,32 @@ export function reducer(state = initialState, action: CampaignActions): State {
   switch (action.type) {
     case ActionTypes.CAMPAIGN_NEW: {
       return { ...adapter.removeAll(state), campaignId: undefined };
+    }
+    case ActionTypes.CAMPAIGN_DUP_FROM_FORM: {
+      return adapter.addAll(
+        action.payload.flights.map((flight, i) => {
+          const tempId = action.payload.timestamp + i;
+          return {
+            id: tempId,
+            localFlight: duplicateFlight(flight, tempId),
+            changed: true,
+            valid: false
+          };
+        }),
+        state
+      );
+    }
+    case ActionTypes.CAMPAIGN_DUP_BY_ID_SUCCESS: {
+      const flights = action.payload.flightDocs.map((doc, i) => {
+        const tempId = action.payload.timestamp + i;
+        return {
+          id: tempId,
+          localFlight: duplicateFlight(docToFlight(doc), tempId),
+          changed: true,
+          valid: false
+        };
+      });
+      return adapter.addAll(flights, state);
     }
     case ActionTypes.CAMPAIGN_LOAD: {
       return {

--- a/src/app/campaign/store/selectors/campaign-flight.selectors.ts
+++ b/src/app/campaign/store/selectors/campaign-flight.selectors.ts
@@ -8,6 +8,7 @@ export const selectCampaignWithFlightsForSave = createSelector(
   selectAllFlights,
   (campaign: CampaignState, flights: FlightState[]): CampaignFormSave => ({
     campaign: campaign.localCampaign,
+    campaignDoc: campaign.doc,
     updatedFlights: flights
       .filter(flight => !flight.softDeleted && flight.changed && flight.remoteFlight)
       .map(flight => flight.localFlight),

--- a/src/app/core/campaign/campaign.service.ts
+++ b/src/app/core/campaign/campaign.service.ts
@@ -11,14 +11,6 @@ import { selectCampaignDoc, selectFlightDocById } from '../../campaign/store/sel
 export class CampaignService {
   constructor(private augury: AuguryService, private store: Store<any>) {}
 
-  get campaignDoc$(): Observable<HalDoc> {
-    return this.store.pipe(
-      select(selectCampaignDoc),
-      filter(doc => !!doc),
-      first()
-    );
-  }
-
   getFlightDocById(id): Observable<HalDoc> {
     return this.store.pipe(
       select(selectFlightDocById, { id }),
@@ -41,16 +33,16 @@ export class CampaignService {
     );
   }
 
-  updateCampaign(campaign: Campaign): Observable<HalDoc> {
-    return this.campaignDoc$.pipe(switchMap(doc => doc.update(campaign)));
+  updateCampaign(doc: HalDoc, campaign: Campaign): Observable<HalDoc> {
+    return doc.update(campaign);
   }
 
   createCampaign(campaign: Campaign): Observable<HalDoc> {
-    return this.augury.root.pipe(switchMap(rootDoc => rootDoc.create('prx:campaign', {}, campaign)));
+    return this.augury.root.pipe(mergeMap(rootDoc => rootDoc.create('prx:campaign', {}, campaign)));
   }
 
-  createFlight(flight: Flight): Observable<HalDoc> {
-    return this.campaignDoc$.pipe(switchMap(doc => doc.create('prx:flights', {}, flight)));
+  createFlight(campaignDoc: HalDoc, flight: Flight): Observable<HalDoc> {
+    return campaignDoc.create('prx:flights', {}, flight);
   }
 
   updateFlight(flight: Flight): Observable<HalDoc> {

--- a/src/app/dashboard/campaign-card/campaign-card.component.scss
+++ b/src/app/dashboard/campaign-card/campaign-card.component.scss
@@ -14,6 +14,9 @@ section {
 
   header {
     padding: 10px 10px 0 10px;
+    display: grid;
+    grid-template-columns: auto min-content;
+    grid-column-gap: 0.25rem;
   }
 
   .content {

--- a/src/app/dashboard/campaign-card/campaign-card.component.spec.ts
+++ b/src/app/dashboard/campaign-card/campaign-card.component.spec.ts
@@ -2,6 +2,7 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
+import { MatIconModule } from '@angular/material';
 
 import { SharedModule } from '../../shared/shared.module';
 
@@ -22,7 +23,7 @@ describe('CampaignCardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, SharedModule],
+      imports: [RouterTestingModule, SharedModule, MatIconModule],
       declarations: [
         CampaignCardComponent,
         CampaignCardAbbreviateNumberPipe,

--- a/src/app/dashboard/campaign-card/campaign-card.component.ts
+++ b/src/app/dashboard/campaign-card/campaign-card.component.ts
@@ -5,7 +5,10 @@ import { Campaign } from '../dashboard.service';
   selector: 'grove-campaign-card',
   template: `
     <section class="{{ campaign?.status }}" *ngIf="campaign">
-      <header>{{ campaign.flights | campaignFlightDates }}</header>
+      <header>
+        {{ campaign.flights | campaignFlightDates }}
+        <a routerLink="/campaign/new" [state]="duplicateCampaignState" title="Dupicate Campaign"><mat-icon>file_copy</mat-icon></a>
+      </header>
       <div class="content">
         <h3>
           <a routerLink="{{ '/campaign/' + campaign.id }}">
@@ -40,5 +43,9 @@ export class CampaignCardComponent {
 
   get progressPercent() {
     return Math.min(1, this.campaign.actualCount / this.campaign.totalGoal) * 100 + '%';
+  }
+
+  get duplicateCampaignState(): { id: number } {
+    return { id: this.campaign.id };
   }
 }

--- a/src/app/dashboard/campaign-list/campaign-list.component.spec.ts
+++ b/src/app/dashboard/campaign-list/campaign-list.component.spec.ts
@@ -5,7 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Subject } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatProgressSpinnerModule } from '@angular/material';
+import { MatProgressSpinnerModule, MatIconModule } from '@angular/material';
 import { MockHalService, PagingModule } from 'ngx-prx-styleguide';
 import { SharedModule } from '../../shared/shared.module';
 
@@ -32,7 +32,7 @@ describe('CampaignListComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, MatProgressSpinnerModule, NoopAnimationsModule, PagingModule, SharedModule],
+      imports: [RouterTestingModule, MatIconModule, MatProgressSpinnerModule, NoopAnimationsModule, PagingModule, SharedModule],
       declarations: [
         CampaignCardComponent,
         CampaignCardAbbreviateNumberPipe,


### PR DESCRIPTION
Closes #42 

Duplicates a campaign either from the campaign form or from the dashboard. Both methods are implemented as routerLinks to `/campaign/new` with state. Campaign/flights from the form can be duplicated synchronously, but campaign/flights from the dashboard are duplicated by id with an asynchronous effect to create the success action that populates state.

Also fixed, a nasty bug in the campaign.service that is currently preventing new flights on new campaigns to be persisted. I removed the campaign HalDoc observable from the campaign.service and am providing it as a parameter to those functions that make Hal API calls. For campaigns that had not yet been persisted, this Observable didn't fire until it saw a campaign HalDoc on the state and then the rest of the Observable chain to create those new flights would fire off. Ugly.