### PR TITLE
flight form id and other fixes

### DIFF
--- a/src/app/campaign/availability/availability.component.ts
+++ b/src/app/campaign/availability/availability.component.ts
@@ -10,7 +10,7 @@ import { Flight, AvailabilityRollup, AvailabilityWeeklyRollup, AvailabilityParam
       Please select Start and End Dates, Series, and Zones to view inventory.
     </p>
     <ng-template #inventory>
-      <grove-goal-form [flight]="flight" [dailyMinimum]="dailyMinimum" (goalChange)="goalChange.emit($event)"></grove-goal-form>
+      <grove-goal-form [flight]="flight" (goalChange)="goalChange.emit($event)"></grove-goal-form>
       <ul class="errors" *ngIf="errors as flightErrors">
         <li class="error" *ngFor="let error of flightErrors"><mat-icon>priority_high</mat-icon> {{ error }}</li>
       </ul>
@@ -97,8 +97,7 @@ export class AvailabilityComponent {
   @Input() zones: InventoryZone[];
   @Input() rollups: AvailabilityRollup[];
   @Input() allocationPreviewError: any;
-  @Input() dailyMinimum: number;
-  @Output() goalChange = new EventEmitter<{ flight: Flight; dailyMinimum: number }>();
+  @Output() goalChange = new EventEmitter<{ flight: Flight }>();
   zoneWeekExpanded = {};
 
   get errors() {

--- a/src/app/campaign/availability/availability.component.ts
+++ b/src/app/campaign/availability/availability.component.ts
@@ -97,7 +97,7 @@ export class AvailabilityComponent {
   @Input() zones: InventoryZone[];
   @Input() rollups: AvailabilityRollup[];
   @Input() allocationPreviewError: any;
-  @Output() goalChange = new EventEmitter<{ flight: Flight }>();
+  @Output() goalChange = new EventEmitter<Flight>();
   zoneWeekExpanded = {};
 
   get errors() {

--- a/src/app/campaign/availability/goal-form.component.spec.ts
+++ b/src/app/campaign/availability/goal-form.component.spec.ts
@@ -44,7 +44,7 @@ describe('GoalFormComponent', () => {
   it('emits form changes', done => {
     comp.flight = flight;
     comp.goalChange.subscribe(change => {
-      expect(change).toMatchObject({ dailyMinimum: 90, flight });
+      expect(change).toMatchObject({ ...flight, dailyMinimum: 90 });
       done();
     });
     comp.goalForm.get('dailyMinimum').setValue(90);

--- a/src/app/campaign/availability/goal-form.component.ts
+++ b/src/app/campaign/availability/goal-form.component.ts
@@ -31,20 +31,10 @@ export class GoalFormComponent implements OnInit, OnDestroy {
   set flight(flight: Flight) {
     if (flight) {
       this._flight = flight;
-      this.updateGoalForm({ totalGoal: this._flight.totalGoal });
+      this.updateGoalForm({ totalGoal: this._flight.totalGoal, dailyMinimum: this._flight.dailyMinimum });
     }
   }
-  // tslint:disable-next-line
-  private _dailyMinimum: number;
-  get dailyMinimum(): number {
-    return this._dailyMinimum;
-  }
-  @Input()
-  set dailyMinimum(dailyMinimum: number) {
-    this._dailyMinimum = dailyMinimum;
-    this.updateGoalForm({ dailyMinimum });
-  }
-  @Output() goalChange = new EventEmitter<{ flight: Flight; dailyMinimum: number }>();
+  @Output() goalChange = new EventEmitter<{ flight: Flight }>();
   goalForm = this.fb.group({
     totalGoal: ['', Validators.required],
     dailyMinimum: ['']
@@ -76,8 +66,7 @@ export class GoalFormComponent implements OnInit, OnDestroy {
     const totalGoal = formFields.totalGoal && +formFields.totalGoal;
     const dailyMinimum = formFields.dailyMinimum && +formFields.dailyMinimum;
     this.goalChange.emit({
-      flight: { ...this.flight, totalGoal },
-      dailyMinimum
+      flight: { ...this.flight, totalGoal, dailyMinimum }
     });
   }
 

--- a/src/app/campaign/availability/goal-form.component.ts
+++ b/src/app/campaign/availability/goal-form.component.ts
@@ -34,7 +34,7 @@ export class GoalFormComponent implements OnInit, OnDestroy {
       this.updateGoalForm({ totalGoal: this._flight.totalGoal, dailyMinimum: this._flight.dailyMinimum });
     }
   }
-  @Output() goalChange = new EventEmitter<{ flight: Flight }>();
+  @Output() goalChange = new EventEmitter<Flight>();
   goalForm = this.fb.group({
     totalGoal: ['', Validators.required],
     dailyMinimum: ['']
@@ -66,7 +66,9 @@ export class GoalFormComponent implements OnInit, OnDestroy {
     const totalGoal = formFields.totalGoal && +formFields.totalGoal;
     const dailyMinimum = formFields.dailyMinimum && +formFields.dailyMinimum;
     this.goalChange.emit({
-      flight: { ...this.flight, totalGoal, dailyMinimum }
+      ...this.flight,
+      totalGoal,
+      dailyMinimum
     });
   }
 

--- a/src/app/campaign/flight/flight.component.ts
+++ b/src/app/campaign/flight/flight.component.ts
@@ -93,8 +93,8 @@ export class FlightComponent implements OnInit {
   formStatusChanged(flight: Flight, changed?: boolean) {
     if (this.emitFormUpdates) {
       this.flightUpdate.emit({
-        flight: { ...flight, totalGoal: this.flight.totalGoal },
-        changed,
+        flight: { ...flight, totalGoal: this.flight.totalGoal, dailyMinimum: this.flight.dailyMinimum },
+        changed: this.flightForm.dirty,
         valid: this.flightForm.valid
       });
     }
@@ -113,8 +113,7 @@ export class FlightComponent implements OnInit {
       {
         ...this.flight,
         ...(startAt && { startAt }),
-        ...(endAt && { endAt }),
-        totalGoal: this.flight.totalGoal
+        ...(endAt && { endAt })
       },
       true
     );

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -8,7 +8,6 @@ import {
   selectRoutedLocalFlight,
   selectRoutedFlightDeleted,
   selectRoutedFlightChanged,
-  selectRoutedFlightDailyMinimum,
   selectCurrentInventoryUri,
   selectRoutedFlightAllocationPreviewError,
   selectAvailabilityRollup
@@ -34,8 +33,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
         [zones]="zoneOpts"
         [rollups]="flightAvailabilityRollup$ | async"
         [allocationPreviewError]="allocationPreviewError$ | async"
-        [dailyMinimum]="flightDailyMin$ | async"
-        (goalChange)="onGoalChange($event.flight, $event.dailyMinimum)"
+        (goalChange)="onGoalChange($event.flight)"
       >
       </grove-availability>
     </ng-container>
@@ -48,7 +46,6 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
   softDeleted$: Observable<boolean>;
   flightChanged$: Observable<boolean>;
   flightAvailabilityRollup$: Observable<AvailabilityRollup[]>;
-  flightDailyMin$: Observable<number>;
   currentInventoryUri$: Observable<string>;
   allocationPreviewError$: Observable<any>;
   inventoryOptions$: Observable<Inventory[]>;
@@ -61,7 +58,6 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
     this.flightLocal$ = this.store.pipe(select(selectRoutedLocalFlight));
     this.softDeleted$ = this.store.pipe(select(selectRoutedFlightDeleted));
     this.flightChanged$ = this.store.pipe(select(selectRoutedFlightChanged));
-    this.flightDailyMin$ = this.store.pipe(select(selectRoutedFlightDailyMinimum));
     this.currentInventoryUri$ = this.store.pipe(select(selectCurrentInventoryUri));
     this.allocationPreviewError$ = this.store.pipe(select(selectRoutedFlightAllocationPreviewError));
     this.flightAvailabilityRollup$ = this.store.pipe(select(selectAvailabilityRollup));
@@ -85,8 +81,8 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
     this.campaignAction.updateFlightForm(formFlight, changed, valid);
   }
 
-  onGoalChange(flight: Flight, dailyMinimum: number) {
-    this.campaignAction.setFlightGoal(flight.id, flight.totalGoal, dailyMinimum);
+  onGoalChange(flight: Flight) {
+    this.campaignAction.setFlightGoal(flight);
   }
 
   flightDuplicate(flight: Flight) {

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -33,7 +33,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
         [zones]="zoneOpts"
         [rollups]="flightAvailabilityRollup$ | async"
         [allocationPreviewError]="allocationPreviewError$ | async"
-        (goalChange)="onGoalChange($event.flight)"
+        (goalChange)="onGoalChange($event)"
       >
       </grove-availability>
     </ng-container>

--- a/src/app/campaign/form/campaign-form.container.ts
+++ b/src/app/campaign/form/campaign-form.container.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { Store, select } from '@ngrx/store';
 import { Account, Advertiser } from '../store/models';
 import { Campaign } from '../store/models';
-import { selectLocalCampaign, selectAllAccounts, selectAllAdvertisers } from '../store/selectors';
+import { selectLocalCampaign, selectAllAccounts, selectAllAdvertisersOrderByName } from '../store/selectors';
 import * as campaignActions from '../store/actions/campaign-action.creator';
 import * as advertiserActions from '../store/actions/advertiser-action.creator';
 
@@ -30,7 +30,7 @@ export class CampaignFormContainerComponent implements OnInit {
 
   ngOnInit() {
     this.accounts$ = this.store.pipe(select(selectAllAccounts));
-    this.advertisers$ = this.store.pipe(select(selectAllAdvertisers));
+    this.advertisers$ = this.store.pipe(select(selectAllAdvertisersOrderByName));
     this.campaign$ = this.store.pipe(select(selectLocalCampaign));
   }
 

--- a/src/app/campaign/nav/campaign-nav.component.ts
+++ b/src/app/campaign/nav/campaign-nav.component.ts
@@ -9,7 +9,7 @@ import { Campaign, Flight, FlightState } from '../store/models';
       <a
         mat-list-item
         *ngFor="let flight of flights; let i = index"
-        [routerLink]="['flight', flight.id]"
+        [routerLink]="['flight', flight?.localFlight?.id]"
         routerLinkActive="active-link"
         [class.deleted-flight]="flight.softDeleted"
         [class.changed]="flight.changed"

--- a/src/app/campaign/store/actions/campaign-action.service.spec.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.spec.ts
@@ -48,13 +48,6 @@ describe('CampaignActionService', () => {
     fixture.ngZone.run(() => {
       const loadAction = new campaignActions.CampaignLoadSuccess({ campaignDoc, flightDocs });
       store.dispatch(loadAction);
-      const goalAction = new campaignActions.CampaignFlightSetGoal({
-        flightId: flightIds[0],
-        totalGoal: 999,
-        dailyMinimum: 9,
-        valid: true
-      });
-      store.dispatch(goalAction);
 
       router
         .navigateByUrl(`/campaign/${campaignFixture.id}/flight/${flightFixture.id}`)
@@ -73,16 +66,15 @@ describe('CampaignActionService', () => {
   });
 
   it('should dispatch action to load allocation preview', () => {
-    const { id: flightId, name, startAt, totalGoal, set_inventory_uri, zones } = flightFixture;
+    const { id: flightId, name, startAt, totalGoal, dailyMinimum, set_inventory_uri, zones } = flightFixture;
     const endAt = new Date();
     const createdAt = new Date();
-    const dailyMinimum = 100;
 
     const formFlight = { ...flightFixture, endAt };
     const localFlight = { ...flightFixture, createdAt };
-    service.loadAvailabilityAllocationIfChanged(formFlight, localFlight, 100);
+    service.loadAvailabilityAllocationIfChanged(formFlight, localFlight);
 
-    expect(dispatchSpy).toHaveBeenCalledWith(
+    expect(dispatchSpy).toHaveBeenLastCalledWith(
       new allocationPreviewActions.AllocationPreviewLoad({
         flightId,
         createdAt,
@@ -99,7 +91,7 @@ describe('CampaignActionService', () => {
 
   it('should not load allocation preview if just the flight name changes', () => {
     const changedFlight = { ...flightFixture, name: 'new name' };
-    service.loadAvailabilityAllocationIfChanged(changedFlight, flightFixture, 100);
+    service.loadAvailabilityAllocationIfChanged(changedFlight, flightFixture);
     expect(store.dispatch).not.toHaveBeenCalled();
   });
 
@@ -137,17 +129,17 @@ describe('CampaignActionService', () => {
   });
 
   it('should dispatch action to set flight goal', () => {
-    const flightId = flightFixture.id;
     const totalGoal = 1000;
     const dailyMinimum = 10;
-    service.setFlightGoal(flightId, totalGoal, dailyMinimum);
-    expect(dispatchSpy).toHaveBeenCalledWith(new campaignActions.CampaignFlightSetGoal({ flightId, totalGoal, dailyMinimum, valid: true }));
+    service.setFlightGoal({ ...flightFixture, totalGoal, dailyMinimum });
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      new campaignActions.CampaignFlightSetGoal({ flightId: flightFixture.id, totalGoal, dailyMinimum, valid: true })
+    );
   });
 
   it('should load allocation preview when total goal is changed', () => {
-    const { id: flightId, createdAt, name, startAt, endAt, set_inventory_uri, zones, totalGoal } = flightFixture;
-    const dailyMinimum = 10;
-    service.setFlightGoal(flightId, totalGoal, dailyMinimum);
+    const { id: flightId, createdAt, name, startAt, endAt, set_inventory_uri, zones, totalGoal, dailyMinimum } = flightFixture;
+    service.setFlightGoal(flightFixture);
     expect(dispatchSpy).toHaveBeenLastCalledWith(
       new allocationPreviewActions.AllocationPreviewLoad({
         flightId,

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -118,17 +118,19 @@ export class CampaignActionService implements OnDestroy {
     this.store
       .pipe(
         select(selectRoutedFlight),
-        filter(state => !!(state && state.id)),
+        filter(state => !!(state && state.localFlight)),
         first()
       )
-      .subscribe(state => this.store.dispatch(new campaignActions.CampaignDeleteFlight({ id: state.id, softDeleted: !state.softDeleted })));
+      .subscribe(state =>
+        this.store.dispatch(new campaignActions.CampaignDeleteFlight({ id: state.localFlight.id, softDeleted: !state.softDeleted }))
+      );
   }
 
   updateFlightForm(formFlight: Flight, changed: boolean, valid: boolean) {
     this.store
       .pipe(
         select(selectRoutedFlight),
-        filter(state => !!(state && state.id)),
+        filter(state => !!(state && state.localFlight)),
         first()
       )
       .subscribe(state => {

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -109,7 +109,6 @@ export const createFlightsState = campaignDoc => ({
     ids: [flightFixture.id],
     entities: {
       [flightFixture.id]: {
-        id: flightFixture.id,
         localFlight: flightFixture,
         remoteFlight: flightFixture,
         dailyMinimum: 99,

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -94,6 +94,7 @@ export const flightFixture: Flight = {
   startAt: new Date('2019-10-01'),
   endAt: new Date('2019-11-01'),
   totalGoal: 999,
+  dailyMinimum: 99,
   zones: [{ id: 'pre_1', label: 'Preroll 1' }],
   set_inventory_uri: '/some/inventory'
 };
@@ -111,7 +112,6 @@ export const createFlightsState = campaignDoc => ({
       [flightFixture.id]: {
         localFlight: flightFixture,
         remoteFlight: flightFixture,
-        dailyMinimum: 99,
         changed: false,
         valid: true,
         softDeleted: false,

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -14,19 +14,19 @@ export interface Flight {
   name: string;
   startAt: Date;
   endAt: Date;
-  totalGoal: number;
+  set_inventory_uri: string;
   zones: FlightZone[];
+  totalGoal: number;
+  dailyMinimum?: number;
   status?: string;
   status_message?: string;
   createdAt?: Date;
-  set_inventory_uri: string;
 }
 
 export interface FlightState {
   doc?: HalDoc;
   localFlight: Flight;
   remoteFlight?: Flight;
-  dailyMinimum?: number;
   changed: boolean;
   valid: boolean;
   softDeleted?: boolean;

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -23,7 +23,6 @@ export interface Flight {
 }
 
 export interface FlightState {
-  id: number;
   doc?: HalDoc;
   localFlight: Flight;
   remoteFlight?: Flight;
@@ -51,4 +50,8 @@ export const duplicateFlight = (flight: Flight, tempId: number): Flight => {
   const { createdAt, startAt, endAt, ...dupFlight } = flight;
   dupFlight.id = tempId;
   return dupFlight as Flight;
+};
+
+export const getFlightId = (state: FlightState) => {
+  return state.localFlight && state.localFlight.id;
 };

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -116,7 +116,7 @@ describe('Flight Reducer', () => {
       new campaignActions.CampaignFlightSetGoal({ flightId: flightFixture.id, totalGoal: 999, dailyMinimum: 99, valid: true })
     );
     expect(result.entities[flightFixture.id].localFlight.totalGoal).toBe(999);
-    expect(result.entities[flightFixture.id].dailyMinimum).toBe(99);
+    expect(result.entities[flightFixture.id].localFlight.dailyMinimum).toBe(99);
   });
 
   it('should update flights from campaign save action', () => {

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -1,7 +1,6 @@
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import { ActionTypes } from '../actions/action.types';
 import { CampaignActions } from '../actions/campaign-action.creator';
-import { docToFlight, Flight, FlightState, duplicateFlight } from '../models';
 import { docToFlight, duplicateFlight, Flight, FlightState, getFlightId } from '../models';
 
 export interface State extends EntityState<FlightState> {
@@ -108,7 +107,7 @@ export function reducer(state = initialState, action: CampaignActions): State {
     case ActionTypes.CAMPAIGN_FLIGHT_SET_GOAL: {
       const { flightId: id, totalGoal, dailyMinimum, valid } = action.payload;
       return adapter.updateOne(
-        { id, changes: { localFlight: { ...state.entities[id].localFlight, totalGoal }, dailyMinimum, changed: true, valid } },
+        { id, changes: { localFlight: { ...state.entities[id].localFlight, totalGoal, dailyMinimum }, changed: true, valid } },
         state
       );
     }

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -68,6 +68,7 @@ export function reducer(state = initialState, action: CampaignActions): State {
       const { flightId: id, startAt, endAt } = action.payload;
       const initialFlightState: FlightState = {
         localFlight: {
+          id,
           name: 'New Flight ' + (state.ids.length + 1),
           startAt,
           endAt,

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -108,7 +108,10 @@ export function reducer(state = initialState, action: CampaignActions): State {
     case ActionTypes.CAMPAIGN_FLIGHT_SET_GOAL: {
       const { flightId: id, totalGoal, dailyMinimum, valid } = action.payload;
       return adapter.updateOne(
-        { id, changes: { localFlight: { ...state.entities[id].localFlight, totalGoal, dailyMinimum }, changed: true, valid } },
+        {
+          id,
+          changes: { localFlight: { ...state.entities[id].localFlight, totalGoal, dailyMinimum: dailyMinimum || 0 }, changed: true, valid }
+        },
         state
       );
     }

--- a/src/app/campaign/store/selectors/advertiser.selectors.ts
+++ b/src/app/campaign/store/selectors/advertiser.selectors.ts
@@ -8,3 +8,8 @@ export const selectAdvertiserState = createSelector(selectCampaignStoreState, (s
 export const selectAdvertiserIds = createSelector(selectAdvertiserState, selectIds);
 export const selectAdvertiserEntities = createSelector(selectAdvertiserState, selectEntities);
 export const selectAllAdvertisers = createSelector(selectAdvertiserState, selectAll);
+
+export const selectAllAdvertisersOrderByName = createSelector(
+  selectAllAdvertisers,
+  advertisers => advertisers && advertisers.sort((a, b) => a.name.localeCompare(b.name))
+);

--- a/src/app/campaign/store/selectors/flight.selectors.spec.ts
+++ b/src/app/campaign/store/selectors/flight.selectors.spec.ts
@@ -51,14 +51,6 @@ describe('Flight Selectors', () => {
     expect(changed).toEqual(flightState.changed);
   });
 
-  it('should select routed flight daily minimum', () => {
-    const flightState = campaignStateFactory.createFlightsState(new MockHalDoc(campaignStateFactory.campaignDocFixture)).flights.entities[
-      campaignStateFactory.flightFixture.id
-    ];
-    const dailyMinimum = flightSelectors.selectRoutedFlightDailyMinimum.projector(flightState);
-    expect(dailyMinimum).toEqual(flightState.dailyMinimum);
-  });
-
   it('should select flight doc by id', () => {
     const state = campaignStateFactory.createFlightsState(new MockHalDoc(campaignStateFactory.campaignDocFixture));
     const doc = flightSelectors.selectFlightDocById.projector(state.flights.entities, { id: campaignStateFactory.flightFixture.id });

--- a/src/app/campaign/store/selectors/flight.selectors.ts
+++ b/src/app/campaign/store/selectors/flight.selectors.ts
@@ -12,7 +12,7 @@ export const selectFlightEntities = createSelector(selectFlightsState, selectEnt
 export const selectAllFlights = createSelector(selectFlightsState, selectAll);
 
 export const selectAllFlightsOrderByCreatedAt = createSelector(selectAllFlights, flights =>
-  flights.sort((a, b) => (a.localFlight.createdAt || a.id).valueOf() - (b.localFlight.createdAt || b.id).valueOf())
+  flights.sort((a, b) => (a.localFlight.createdAt || a.localFlight.id).valueOf() - (b.localFlight.createdAt || b.localFlight.id).valueOf())
 );
 
 export const selectRoutedFlightId = createSelector(selectRouterStateParams, (params): number => params && +params.flightId);

--- a/src/app/campaign/store/selectors/flight.selectors.ts
+++ b/src/app/campaign/store/selectors/flight.selectors.ts
@@ -42,10 +42,6 @@ export const selectRoutedFlightChanged = createSelector(
   selectRoutedFlight,
   (flightState: FlightState): boolean => flightState && flightState.changed
 );
-export const selectRoutedFlightDailyMinimum = createSelector(
-  selectRoutedFlight,
-  (flightState: FlightState): number => flightState && flightState.dailyMinimum
-);
 export const selectFlightDocById = createSelector(
   selectFlightEntities,
   (flights: { [id: number]: FlightState }, props: { id: number }): HalDoc => flights && flights[props.id].doc


### PR DESCRIPTION
* Fixes the flight form id and removes the boolean valueChanges guard. I fixed a couple other things in testing, and I feel confident about removing that guard.
* Cleans up the FlightState and Flight models to use the localFlight.id instead of having that id field duplicated into FlightState
* Sets the dailyMinimum on flights instead of just using it for preview
* Also sorts advertisers by name to improve the autocomplete selection. I couldn't replicate the bug with adding new advertisers instead of selecting existing ones, but I did find selection awkward with similarly named advertisers when they weren't sorted.