### PR TITLE
Fix flight form emit

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/core": "~7.2.0",
     "@angular/forms": "~7.2.0",
     "@angular/material": "~7.3.7",
+    "@angular/material-moment-adapter": "~7.3.7",
     "@angular/platform-browser": "~7.2.0",
     "@angular/platform-browser-dynamic": "~7.2.0",
     "@angular/router": "~7.2.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,14 @@ import { ErrorService } from './error/error.service';
 import { AppRoutingModule, routingComponents } from './app.routing.module';
 import { AppComponent } from './app.component';
 
+import { DateAdapter, MAT_DATE_LOCALE, MAT_DATE_FORMATS } from '@angular/material';
+import {
+  MatMomentDateModule,
+  MomentDateAdapter,
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+  MAT_MOMENT_DATE_FORMATS
+} from '@angular/material-moment-adapter';
+
 import { CoreModule } from './core/core.module';
 import { SharedModule } from './shared/shared.module';
 import { CampaignModule } from './campaign/campaign.module';
@@ -34,13 +42,19 @@ import { environment } from '../environments/environment';
     CampaignModule,
     BrowserAnimationsModule,
     DashboardModule,
+    MatMomentDateModule,
     StoreModule.forRoot(reducers, { metaReducers }),
     StoreModule.forRoot({ router: routerReducer }),
     StoreRouterConnectingModule.forRoot({ serializer: CustomRouterSerializer }),
     EffectsModule.forRoot([]),
     !environment.production ? StoreDevtoolsModule.instrument() : []
   ],
-  providers: [{ provide: ErrorHandler, useClass: ErrorService }],
+  providers: [
+    { provide: ErrorHandler, useClass: ErrorService },
+    { provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS] },
+    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } },
+    { provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/src/app/campaign/availability/availability.component.spec.ts
+++ b/src/app/campaign/availability/availability.component.spec.ts
@@ -10,6 +10,7 @@ import { GoalFormComponent } from './goal-form.component';
 import { InventoryZone } from '../../core';
 import { Flight, AvailabilityRollup } from '../store/models';
 import { availabilityParamsFixture } from '../store/models/campaign-state.factory';
+import * as moment from 'moment';
 
 describe('AvailabilityComponent', () => {
   let comp: AvailabilityComponent;
@@ -55,8 +56,8 @@ describe('AvailabilityComponent', () => {
   const mockFlight: Flight = {
     id: 9,
     name: 'my flight name',
-    startAt: new Date('2019-10-01'),
-    endAt: new Date('2019-11-01'),
+    startAt: moment.utc('2019-10-01'),
+    endAt: moment.utc('2019-11-01'),
     totalGoal: 999,
     zones: [{ id: 'pre_1', label: 'Preroll 1' }],
     set_inventory_uri: '/some/inventory'

--- a/src/app/campaign/availability/goal-form.component.spec.ts
+++ b/src/app/campaign/availability/goal-form.component.spec.ts
@@ -1,11 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatFormFieldModule, MatInputModule } from '@angular/material';
 import { SharedModule } from '../../shared/shared.module';
 import { GoalFormComponent } from './goal-form.component';
+import * as moment from 'moment';
 
 describe('GoalFormComponent', () => {
   let comp: GoalFormComponent;
@@ -15,8 +15,8 @@ describe('GoalFormComponent', () => {
   const flight = {
     id: 9,
     name: 'my flight name',
-    startAt: new Date('2019-10-01'),
-    endAt: new Date('2019-11-01'),
+    startAt: moment.utc(),
+    endAt: moment.utc(),
     totalGoal: 999,
     zones: [{ id: 'pre_1', label: 'Preroll 1' }],
     set_inventory_uri: '/some/inventory'

--- a/src/app/campaign/availability/goal-form.component.ts
+++ b/src/app/campaign/availability/goal-form.component.ts
@@ -31,11 +31,12 @@ export class GoalFormComponent implements OnInit, OnDestroy {
   set flight(flight: Flight) {
     if (flight) {
       this._flight = flight;
-      this.updateGoalForm({ totalGoal: this._flight.totalGoal, dailyMinimum: this._flight.dailyMinimum });
+      this.updateGoalForm(flight);
     }
   }
   @Output() goalChange = new EventEmitter<Flight>();
   goalForm = this.fb.group({
+    id: [''],
     totalGoal: ['', Validators.required],
     dailyMinimum: ['']
   });
@@ -67,16 +68,13 @@ export class GoalFormComponent implements OnInit, OnDestroy {
     const dailyMinimum = formFields.dailyMinimum && +formFields.dailyMinimum;
     this.goalChange.emit({
       ...this.flight,
+      id: formFields.id,
       totalGoal,
       dailyMinimum
     });
   }
 
-  updateGoalForm(params: { totalGoal?: number; dailyMinimum?: number }) {
-    const { totalGoal, dailyMinimum } = params;
-    this.goalForm.patchValue(
-      { ...(totalGoal && { totalGoal }), ...((dailyMinimum || dailyMinimum === 0) && { dailyMinimum }) },
-      { emitEvent: false, onlySelf: true }
-    );
+  updateGoalForm({ id, totalGoal, dailyMinimum }: Flight) {
+    this.goalForm.patchValue({ id, totalGoal, dailyMinimum }, { emitEvent: false, onlySelf: true });
   }
 }

--- a/src/app/campaign/availability/goal-form.component.ts
+++ b/src/app/campaign/availability/goal-form.component.ts
@@ -75,6 +75,6 @@ export class GoalFormComponent implements OnInit, OnDestroy {
   }
 
   updateGoalForm({ id, totalGoal, dailyMinimum }: Flight) {
-    this.goalForm.patchValue({ id, totalGoal, dailyMinimum }, { emitEvent: false, onlySelf: true });
+    this.goalForm.reset({ id, totalGoal, dailyMinimum }, { emitEvent: false, onlySelf: true });
   }
 }

--- a/src/app/campaign/campaign.component.spec.ts
+++ b/src/app/campaign/campaign.component.spec.ts
@@ -101,34 +101,38 @@ describe('CampaignComponent', () => {
     });
   });
 
-  it('calls action to duplicate a campaign by id', done => {
-    jest.spyOn(store, 'dispatch');
-    // id is passed through the /camp[aign/new router link state
-    Object.defineProperty(window.history, 'state', { writable: true, value: { id: 123 } });
-    fix.ngZone.run(() => {
-      router.navigateByUrl('/campaign/new');
-      route.setParamMap({});
-      route.paramMap.pipe(first()).subscribe(() => {
-        expect(store.dispatch).toHaveBeenLastCalledWith(new campaignActions.CampaignDupById({ id: 123 }));
-        done();
+  describe('temporary flightId timestamp', () => {
+    // mock the flight tempId
+    const timestamp = Date.now();
+    beforeEach(() => {
+      global.Date.now = jest.fn(() => timestamp);
+      jest.spyOn(store, 'dispatch');
+    });
+    it('calls action to duplicate a campaign by id', done => {
+      // id is passed through the /camp[aign/new router link state
+      Object.defineProperty(window.history, 'state', { writable: true, value: { id: 123 } });
+      fix.ngZone.run(() => {
+        router.navigateByUrl('/campaign/new');
+        route.setParamMap({});
+        route.paramMap.pipe(first()).subscribe(() => {
+          expect(store.dispatch).toHaveBeenLastCalledWith(new campaignActions.CampaignDupById({ id: 123, timestamp }));
+          done();
+        });
       });
     });
-  });
 
-  it('calls action to duplicate a campaign from form', done => {
-    jest.spyOn(store, 'dispatch');
-    // mock the flight tempId
-    Date.now = jest.fn(() => 12345);
-    // campaign and flights are passed through the /capaign/new router link state
-    Object.defineProperty(window.history, 'state', { writable: true, value: { campaign: campaignFixture, flights: [flightFixture] } });
-    fix.ngZone.run(() => {
-      router.navigateByUrl('/campaign/new');
-      route.setParamMap({});
-      route.paramMap.pipe(first()).subscribe(() => {
-        expect(store.dispatch).toHaveBeenLastCalledWith(
-          new campaignActions.CampaignDupFromForm({ campaign: campaignFixture, flights: [flightFixture] })
-        );
-        done();
+    it('calls action to duplicate a campaign from form', done => {
+      // campaign and flights are passed through the /capaign/new router link state
+      Object.defineProperty(window.history, 'state', { writable: true, value: { campaign: campaignFixture, flights: [flightFixture] } });
+      fix.ngZone.run(() => {
+        router.navigateByUrl('/campaign/new');
+        route.setParamMap({});
+        route.paramMap.pipe(first()).subscribe(() => {
+          expect(store.dispatch).toHaveBeenLastCalledWith(
+            new campaignActions.CampaignDupFromForm({ campaign: campaignFixture, flights: [flightFixture], timestamp })
+          );
+          done();
+        });
       });
     });
   });

--- a/src/app/campaign/campaign.module.ts
+++ b/src/app/campaign/campaign.module.ts
@@ -4,6 +4,7 @@ import { SharedModule } from '../shared/shared.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { campaignRouting, campaignComponents } from './campaign.routing';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatCardModule } from '@angular/material/card';
@@ -12,7 +13,7 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { StatusBarModule, FancyFormModule, DatepickerModule } from 'ngx-prx-styleguide';
+import { StatusBarModule, FancyFormModule } from 'ngx-prx-styleguide';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 import * as fromCampaignState from './store';
@@ -29,6 +30,7 @@ import { CampaignActionService } from './store/actions/campaign-action.service';
     SharedModule,
     MatCardModule,
     MatButtonModule,
+    MatDatepickerModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
@@ -40,7 +42,6 @@ import { CampaignActionService } from './store/actions/campaign-action.service';
     ReactiveFormsModule,
     StatusBarModule,
     FancyFormModule,
-    DatepickerModule,
     campaignRouting,
     StoreModule.forFeature('campaignState', fromCampaignState.reducers, { metaReducers: fromCampaignState.metaReducers }),
     EffectsModule.forFeature([AccountEffects, AdvertiserEffects, AllocationPreviewEffects, AvailabilityEffects, CampaignEffects])

--- a/src/app/campaign/flight/flight.component.html
+++ b/src/app/campaign/flight/flight.component.html
@@ -5,20 +5,18 @@
       <input matInput placeholder="Flight Name" formControlName="name" required />
     </mat-form-field>
     <div class="inline-fields">
-      <prx-datepicker
-        class="flight-form-field"
-        [date]="flight?.startAt"
-        [maxDate]="flight?.endAt"
-        UTC="true"
-        (dateChange)="onDateRangeChange({ startAt: $event })"
-      ></prx-datepicker>
-      <prx-datepicker
-        class="flight-form-field"
-        [date]="flight?.endAt"
-        [minDate]="flight?.startAt"
-        UTC="true"
-        (dateChange)="onDateRangeChange({ endAt: $event })"
-      ></prx-datepicker>
+      <mat-form-field appearance="outline">
+        <mat-label>Start Date</mat-label>
+        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Start Date" formControlName="startAt" />
+        <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+        <mat-datepicker #startPicker></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Actual End Date</mat-label>
+        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="End Date" formControlName="endAt" />
+        <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+        <mat-datepicker #endPicker></mat-datepicker>
+      </mat-form-field>
     </div>
     <mat-form-field class="flight-form-field" appearance="outline">
       <mat-label>Series</mat-label>

--- a/src/app/campaign/flight/flight.component.scss
+++ b/src/app/campaign/flight/flight.component.scss
@@ -27,72 +27,19 @@ mat-card form > * {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   grid-column-gap: 0.5rem;
 }
+
 /*
-.inline-fields > prx-datepicker {
-  position: relative;
-  display: grid;
-  grid-template-columns: 1fr 3rem;
-  justify-items: center;
-  align-items: center;
-  margin-bottom: 20px;
-
-  &::before {
-    content: '';
-    display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    border: 2px solid prx-theme-foreground(divider, 0.87);
-    border-radius: 5px;
-    opacity: 0;
-  }
-
-  &:hover,
-  &:focus-within {
-    &::before {
-      transition: opacity 0.6s cubic-bezier(0.25, 0.8, 0.25, 1), border-color 0.6s cubic-bezier(0.25, 0.8, 0.25, 1);
-      opacity: 1;
-    }
-  }
-
-  &:focus-within {
-    &::before {
-      border-color: $primary;
-    }
-    ::ng-deep {
-      prx-icon {
-        color: $primary;
-      }
-    }
-  }
-
-  ::ng-deep {
-    > * {
-      position: relative;
-      grid-row: 1;
-    }
-    input {
-      grid-column: 1 / -1;
-      width: 100%;
-      height: auto;
-      color: prx-theme-foreground(text);
-      border: 1px solid prx-theme-foreground(divider, 0.12);
-      border-radius: 5px;
-      background: none;
-      padding: 1rem 0.75rem;
-    }
-
-    > span {
-      grid-column: 2;
-    }
-
-    prx-icon {
-      transition: color 0.6s cubic-bezier(0.25, 0.8, 0.25, 1);
-      position: unset;
-    }
-  }
-}
+ * override the global button styles
+ * https://github.com/PRX/styleguide.prx.org/issues/212
 */
+::ng-deep button {
+  flex: initial;
+}
+::ng-deep button:hover,
+::ng-deep button[disabled] {
+  background-color: initial;
+}
+
 .flight-controls-container {
   display: flex;
   justify-content: flex-end;

--- a/src/app/campaign/flight/flight.component.scss
+++ b/src/app/campaign/flight/flight.component.scss
@@ -27,6 +27,7 @@ mat-card form > * {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   grid-column-gap: 0.5rem;
 }
+/*
 .inline-fields > prx-datepicker {
   position: relative;
   display: grid;
@@ -91,7 +92,7 @@ mat-card form > * {
     }
   }
 }
-
+*/
 .flight-controls-container {
   display: flex;
   justify-content: flex-end;

--- a/src/app/campaign/flight/flight.component.spec.ts
+++ b/src/app/campaign/flight/flight.component.spec.ts
@@ -1,10 +1,27 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatCardModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatIconModule } from '@angular/material';
+import {
+  MatCardModule,
+  MatFormFieldModule,
+  MatInputModule,
+  MatSelectModule,
+  MatButtonModule,
+  MatIconModule,
+  MatDatepickerModule,
+  DateAdapter,
+  MAT_DATE_LOCALE,
+  MAT_DATE_FORMATS
+} from '@angular/material';
+import {
+  MatMomentDateModule,
+  MomentDateAdapter,
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+  MAT_MOMENT_DATE_FORMATS
+} from '@angular/material-moment-adapter';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FlightComponent } from './flight.component';
 import { Flight } from '../store/models';
-import { DatepickerModule } from 'ngx-prx-styleguide';
+import * as moment from 'moment';
 
 describe('FlightComponent', () => {
   let component: FlightComponent;
@@ -20,22 +37,25 @@ describe('FlightComponent', () => {
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
-        DatepickerModule,
+        MatDatepickerModule,
+        MatMomentDateModule,
         MatButtonModule,
         MatIconModule
       ],
-      declarations: [FlightComponent]
+      declarations: [FlightComponent],
+      providers: [
+        { provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS] },
+        { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } },
+        { provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS }
+      ]
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    const today = new Date();
-    const startAt = new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate()));
-    const endAt = new Date(Date.UTC(today.getFullYear(), today.getMonth() + 1, today.getDate()));
     flightFixture = {
       name: 'my-flight',
-      startAt,
-      endAt,
+      startAt: moment.utc(),
+      endAt: moment.utc(),
       totalGoal: 123,
       zones: [{ id: 'pre_1' }],
       set_inventory_uri: '/some/inventory'
@@ -58,16 +78,6 @@ describe('FlightComponent', () => {
       done();
     });
     component.name.setValue('brand new name');
-  });
-
-  it('emits date range changes', done => {
-    const startAt = new Date('2019-10-20');
-    component.flight = flightFixture;
-    component.flightUpdate.subscribe(updates => {
-      expect(updates).toMatchObject({ flight: { ...flightFixture, startAt }, changed: true });
-      done();
-    });
-    component.onDateRangeChange({ startAt });
   });
 
   it('emits flight duplicate', done => {
@@ -126,13 +136,13 @@ describe('FlightComponent', () => {
   it('updates zone controls to match the flight', () => {
     component.flight = { ...flightFixture, zones: [{ id: 'pre_1' }, { id: 'pre_2', url: 'http://file.mp3' }] };
     expect(component.zones.value).toEqual([
-      { id: 'pre_1', url: null },
+      { id: 'pre_1', url: '' },
       { id: 'pre_2', url: 'http://file.mp3' }
     ]);
 
     // should keep 1 around - can't have 0 zones
     component.flight = { ...flightFixture, zones: [] };
-    expect(component.zones.value).toEqual([{ id: null, url: null }]);
+    expect(component.zones.value).toEqual([{ id: 'pre_1', url: '' }]);
   });
 
   it('adds and removes zone controls', () => {
@@ -141,11 +151,11 @@ describe('FlightComponent', () => {
       { id: 'pre_1', label: 'Preroll 1' },
       { id: 'pre_2', label: 'Preroll 2' }
     ];
-    expect(component.zones.value).toEqual([{ id: 'pre_1', url: null }]);
+    expect(component.zones.value).toEqual([{ id: 'pre_1', url: '' }]);
 
     component.onAddZone();
     expect(component.zones.value).toEqual([
-      { id: 'pre_1', url: null },
+      { id: 'pre_1', url: '' },
       { id: 'pre_2', url: null }
     ]);
 

--- a/src/app/campaign/flight/flight.component.spec.ts
+++ b/src/app/campaign/flight/flight.component.spec.ts
@@ -136,13 +136,13 @@ describe('FlightComponent', () => {
   it('updates zone controls to match the flight', () => {
     component.flight = { ...flightFixture, zones: [{ id: 'pre_1' }, { id: 'pre_2', url: 'http://file.mp3' }] };
     expect(component.zones.value).toEqual([
-      { id: 'pre_1', url: '' },
+      { id: 'pre_1', url: null },
       { id: 'pre_2', url: 'http://file.mp3' }
     ]);
 
     // should keep 1 around - can't have 0 zones
     component.flight = { ...flightFixture, zones: [] };
-    expect(component.zones.value).toEqual([{ id: 'pre_1', url: '' }]);
+    expect(component.zones.value).toEqual([{ id: null, url: null }]);
   });
 
   it('adds and removes zone controls', () => {
@@ -151,11 +151,11 @@ describe('FlightComponent', () => {
       { id: 'pre_1', label: 'Preroll 1' },
       { id: 'pre_2', label: 'Preroll 2' }
     ];
-    expect(component.zones.value).toEqual([{ id: 'pre_1', url: '' }]);
+    expect(component.zones.value).toEqual([{ id: 'pre_1', url: null }]);
 
     component.onAddZone();
     expect(component.zones.value).toEqual([
-      { id: 'pre_1', url: '' },
+      { id: 'pre_1', url: null },
       { id: 'pre_2', url: null }
     ]);
 

--- a/src/app/campaign/flight/flight.component.ts
+++ b/src/app/campaign/flight/flight.component.ts
@@ -122,7 +122,7 @@ export class FlightComponent implements OnInit {
     }
 
     // reset the form
-    this.flightForm.patchValue(flight, { emitEvent: false });
+    this.flightForm.reset(flight, { emitEvent: false });
   }
 
   onAddZone() {

--- a/src/app/campaign/flight/flight.container.spec.ts
+++ b/src/app/campaign/flight/flight.container.spec.ts
@@ -5,12 +5,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import {
   MatButtonModule,
   MatCardModule,
+  MatDatepickerModule,
   MatFormFieldModule,
   MatIconModule,
   MatInputModule,
   MatListModule,
   MatSelectModule
 } from '@angular/material';
+import { MatMomentDateModule } from '@angular/material-moment-adapter';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ReplaySubject } from 'rxjs';
 import { ActivatedRoute, Router, Routes } from '@angular/router';
@@ -18,7 +20,7 @@ import { ActivatedRouteStub } from '../../../testing/stub.router';
 import { Store, StoreModule } from '@ngrx/store';
 import { StoreRouterConnectingModule, routerReducer } from '@ngrx/router-store';
 import { CustomRouterSerializer } from '../../store/router-store/custom-router-serializer';
-import { DatepickerModule, MockHalDoc } from 'ngx-prx-styleguide';
+import { MockHalDoc } from 'ngx-prx-styleguide';
 import { InventoryService } from '../../core';
 import { SharedModule } from '../../shared/shared.module';
 import { flightFixture, flightDocFixture } from '../store/models/campaign-state.factory';
@@ -31,6 +33,7 @@ import { FlightComponent } from './flight.component';
 import { AvailabilityComponent } from '../availability/availability.component';
 import { GoalFormComponent } from '../availability/goal-form.component';
 import { TestComponent } from '../../../testing/test.component';
+import * as moment from 'moment';
 
 const campaignChildRoutes: Routes = [
   { path: '', component: FlightContainerComponent },
@@ -62,8 +65,8 @@ describe('FlightContainerComponent', () => {
   const flight = {
     id: 123,
     name: 'my-flight',
-    startAt: new Date('2019-10-01'),
-    endAt: new Date('2019-11-01'),
+    startAt: moment.utc('2019-10-01'),
+    endAt: moment.utc('2019-11-01'),
     set_inventory_uri: '/some/url',
     zones: [{ id: 'pre_1', label: 'Preroll 1' }],
     totalGoal: 999
@@ -74,11 +77,12 @@ describe('FlightContainerComponent', () => {
       imports: [
         RouterTestingModule.withRoutes(campaignRoutes),
         SharedModule,
-        DatepickerModule,
         ReactiveFormsModule,
         NoopAnimationsModule,
         MatButtonModule,
         MatCardModule,
+        MatDatepickerModule,
+        MatMomentDateModule,
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
@@ -127,7 +131,7 @@ describe('FlightContainerComponent', () => {
   });
 
   it('receives availability and allocation preview updates when flight form changes', done => {
-    component.flightUpdateFromForm({ flight: { ...flightFixture, endAt: new Date() }, changed: true, valid: true });
+    component.flightUpdateFromForm({ flight: { ...flightFixture, endAt: moment.utc() }, changed: true, valid: true });
     component.flightAvailabilityRollup$.subscribe(availability => {
       expect(availability).toBeDefined();
       done();

--- a/src/app/campaign/nav/campaign-nav.component.ts
+++ b/src/app/campaign/nav/campaign-nav.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
-import { Campaign, Flight, FlightState } from '../store/models';
+import { Campaign, FlightState } from '../store/models';
 
 @Component({
   selector: 'grove-campaign-nav',
@@ -44,10 +44,15 @@ export class CampaignNavComponent {
     return !flight.localFlight.status || flight.localFlight.status === 'ok';
   }
 
-  get dupCampaignState(): { campaign: Campaign; flights: Flight[] } {
+  get dupCampaignState(): { campaign; flights } {
     return {
       campaign: this.campaign,
-      flights: this.flights.filter(flight => !flight.softDeleted).map(flight => flight.localFlight)
+      flights: this.flights
+        .filter(flight => !flight.softDeleted)
+        .map(flight => {
+          // NOTE: router does not want to serialize Moment, so passing thru valueOf, startAt/endAt are removed in reducer
+          return { ...flight.localFlight, startAt: flight.localFlight.startAt.valueOf(), endAt: flight.localFlight.endAt.valueOf() };
+        })
     };
   }
 }

--- a/src/app/campaign/store/actions/campaign-action.creator.ts
+++ b/src/app/campaign/store/actions/campaign-action.creator.ts
@@ -2,6 +2,7 @@ import { Action } from '@ngrx/store';
 import { ActionTypes } from './action.types';
 import { Campaign, Flight, CampaignFormSave } from '../models';
 import { HalDoc } from 'ngx-prx-styleguide';
+import { utc, Moment } from 'moment';
 
 export class CampaignNew implements Action {
   readonly type = ActionTypes.CAMPAIGN_NEW;
@@ -20,7 +21,9 @@ export class CampaignDupFromForm implements Action {
 export class CampaignDupById implements Action {
   readonly type = ActionTypes.CAMPAIGN_DUP_BY_ID;
 
-  constructor(public payload: { id: number }) {}
+  constructor(public payload: { id: number; timestamp?: number }) {
+    this.payload.timestamp = payload.timestamp || Date.now();
+  }
 }
 
 export class CampaignDupByIdSuccess implements Action {
@@ -85,25 +88,39 @@ export class CampaignSaveFailure implements Action {
 export class CampaignAddFlight implements Action {
   readonly type = ActionTypes.CAMPAIGN_ADD_FLIGHT;
 
-  constructor(public payload: { campaignId: number | string }) {}
-}
+  public payload: { campaignId: number | string; flightId: number; startAt: Moment; endAt: Moment };
 
-export class CampaignAddFlightWithTempId implements Action {
-  readonly type = ActionTypes.CAMPAIGN_ADD_FLIGHT_WITH_TEMP_ID;
-
-  constructor(public payload: { flightId: number; startAt: Date; endAt: Date }) {}
+  constructor(payload: { campaignId: number | string; flightId?: number; startAt?: Moment; endAt?: Moment }) {
+    const date = utc();
+    this.payload = {
+      campaignId: payload.campaignId,
+      flightId: payload.flightId || date.valueOf(),
+      startAt:
+        payload.startAt ||
+        utc(date.valueOf())
+          .hours(0)
+          .minutes(0)
+          .seconds(0)
+          .milliseconds(0),
+      endAt:
+        payload.endAt ||
+        utc(date.valueOf())
+          .month(date.month() + 1)
+          .date(1)
+          .hours(0)
+          .minutes(0)
+          .seconds(0)
+          .milliseconds(0)
+    };
+  }
 }
 
 export class CampaignDupFlight implements Action {
   readonly type = ActionTypes.CAMPAIGN_DUP_FLIGHT;
 
-  constructor(public payload: { campaignId; flight: Flight }) {}
-}
-
-export class CampaignDupFlightWithTempId implements Action {
-  readonly type = ActionTypes.CAMPAIGN_DUP_FLIGHT_WITH_TEMP_ID;
-
-  constructor(public payload: { flightId: number; flight: Flight }) {}
+  constructor(public payload: { campaignId: number | string; flight: Flight; flightId?: number }) {
+    this.payload.flightId = payload.flightId || Date.now();
+  }
 }
 
 export class CampaignDeleteFlight implements Action {
@@ -137,9 +154,7 @@ export type CampaignActions =
   | CampaignFlightFormUpdate
   | CampaignFlightSetGoal
   | CampaignAddFlight
-  | CampaignAddFlightWithTempId
   | CampaignDupFlight
-  | CampaignDupFlightWithTempId
   | CampaignDeleteFlight
   | CampaignSave
   | CampaignSaveSuccess

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -151,8 +151,10 @@ export class CampaignActionService implements OnDestroy {
   saveCampaignAndFlights() {
     this.store
       .pipe(select(selectCampaignWithFlightsForSave), first())
-      .subscribe(({ campaign, campaignDoc, updatedFlights, createdFlights, deletedFlights }) =>
-        this.store.dispatch(new campaignActions.CampaignSave({ campaign, campaignDoc, updatedFlights, createdFlights, deletedFlights }))
+      .subscribe(({ campaign, campaignDoc, updatedFlights, createdFlights, deletedFlights, tempDeletedFlights }) =>
+        this.store.dispatch(
+          new campaignActions.CampaignSave({ campaign, campaignDoc, updatedFlights, createdFlights, deletedFlights, tempDeletedFlights })
+        )
       );
   }
 }

--- a/src/app/campaign/store/effects/availability.effects.spec.ts
+++ b/src/app/campaign/store/effects/availability.effects.spec.ts
@@ -25,8 +25,8 @@ describe('AvailabilityEffects', () => {
   // load action received by the effect
   const loadAction = new availabilityActions.AvailabilityLoad({
     inventoryId: flightFixture.set_inventory_uri.split('/').pop(),
-    startDate: flightFixture.startAt,
-    endDate: flightFixture.endAt,
+    startDate: flightFixture.startAt.toDate(),
+    endDate: flightFixture.endAt.toDate(),
     zone: flightFixture.zones[0].id,
     flightId: flightFixture.id,
     createdAt: new Date()

--- a/src/app/campaign/store/effects/campaign.effects.spec.ts
+++ b/src/app/campaign/store/effects/campaign.effects.spec.ts
@@ -91,14 +91,16 @@ describe('CampaignEffects', () => {
       campaignDoc: undefined,
       updatedFlights: [],
       createdFlights: [],
-      deletedFlights: []
+      deletedFlights: [],
+      tempDeletedFlights: []
     });
     const updateAction = new campaignActions.CampaignSave({
       campaign: campaignFixture,
       campaignDoc,
       updatedFlights: [],
       createdFlights: [],
-      deletedFlights: []
+      deletedFlights: [],
+      tempDeletedFlights: []
     });
     const success = new campaignActions.CampaignSaveSuccess({
       campaignDoc,
@@ -124,14 +126,16 @@ describe('CampaignEffects', () => {
       campaignDoc: undefined,
       updatedFlights: [],
       createdFlights: [],
-      deletedFlights: []
+      deletedFlights: [],
+      tempDeletedFlights: []
     });
     const updateAction = new campaignActions.CampaignSave({
       campaign: campaignFixture,
       campaignDoc,
       updatedFlights: [],
       createdFlights: [],
-      deletedFlights: []
+      deletedFlights: [],
+      tempDeletedFlights: []
     });
     const outcome = new campaignActions.CampaignSaveFailure({ error: halError });
     actions$.stream = hot('-a-b', { a: createAction, b: updateAction });
@@ -147,7 +151,8 @@ describe('CampaignEffects', () => {
       campaignDoc: undefined,
       updatedFlights: [],
       createdFlights: [],
-      deletedFlights: []
+      deletedFlights: [],
+      tempDeletedFlights: []
     });
     const success = new campaignActions.CampaignSaveSuccess({
       campaignDoc,
@@ -175,7 +180,8 @@ describe('CampaignEffects', () => {
           campaignDoc: undefined,
           updatedFlights: [],
           createdFlights: [flight],
-          deletedFlights: []
+          deletedFlights: [],
+          tempDeletedFlights: []
         });
         const success = new campaignActions.CampaignSaveSuccess({
           campaignDoc,
@@ -202,7 +208,8 @@ describe('CampaignEffects', () => {
           campaignDoc,
           updatedFlights: [],
           createdFlights: [],
-          deletedFlights: [flightFixture]
+          deletedFlights: [flightFixture],
+          tempDeletedFlights: []
         });
         const success = new campaignActions.CampaignSaveSuccess({
           campaignDoc,
@@ -228,7 +235,8 @@ describe('CampaignEffects', () => {
       campaignDoc,
       updatedFlights: [flightFixture],
       createdFlights: [],
-      deletedFlights: []
+      deletedFlights: [],
+      tempDeletedFlights: []
     });
     const success = new campaignActions.CampaignSaveSuccess({
       campaignDoc,

--- a/src/app/campaign/store/effects/campaign.effects.spec.ts
+++ b/src/app/campaign/store/effects/campaign.effects.spec.ts
@@ -241,32 +241,26 @@ describe('CampaignEffects', () => {
     expect(effects.campaignFormSave$).toBeObservable(expected);
   });
 
-  it('should dispatch action to add a flight with a temporary id', () => {
-    const date = new Date();
-    global.Date.now = jest.fn(() => date.getTime());
-    const startAt = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-    const endAt = new Date(Date.UTC(date.getFullYear(), date.getMonth() + 1, 1));
+  it('should navigate to flight added with temporary id', () => {
     const action = new campaignActions.CampaignAddFlight({ campaignId: 1 });
-    const success = new campaignActions.CampaignAddFlightWithTempId({ flightId: date.valueOf(), startAt, endAt });
     actions$.stream = hot('a', { a: action });
-    const expected = cold('r', { r: success });
+    const expected = cold('r', { r: undefined });
     expect(effects.addFlight$).toBeObservable(expected);
+    expect(router.navigate).toHaveBeenCalledWith(['/campaign', 1, 'flight', action.payload.flightId]);
   });
 
-  it('should dispatch action to duplicate flight with a temporary id', () => {
-    const flightId = Date.now();
-    global.Date.now = jest.fn(() => flightId);
+  it('should navigate to flight duplicated with a temporary id', () => {
     const action = new campaignActions.CampaignDupFlight({ campaignId: 1, flight: flightFixture });
-    const success = new campaignActions.CampaignDupFlightWithTempId({ flightId, flight: flightFixture });
     actions$.stream = hot('a', { a: action });
-    const expected = cold('r', { r: success });
+    const expected = cold('r', { r: undefined });
     expect(effects.dupFlight$).toBeObservable(expected);
+    expect(router.navigate).toHaveBeenCalledWith(['/campaign', 1, 'flight', action.payload.flightId]);
   });
 
   it('should get campaign and flights to duplicate by id', () => {
     campaignService.loadCampaignZoomFlights = jest.fn(() => of({ campaignDoc, flightDocs }));
     const action = new campaignActions.CampaignDupById({ id: campaignFixture.id });
-    const success = new campaignActions.CampaignDupByIdSuccess({ campaignDoc, flightDocs });
+    const success = new campaignActions.CampaignDupByIdSuccess({ campaignDoc, flightDocs, timestamp: Date.now() });
     actions$.stream = hot('a', { a: action });
     const expected = cold('r', { r: success });
     expect(effects.dupCampaignById$).toBeObservable(expected);

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -8,6 +8,7 @@ import { AllocationPreview, docToAllocationPreview } from './allocation-preview.
 import { AvailabilityDay, docToAvailabilityDay } from './availability.models';
 import { Campaign } from './campaign.models';
 import { Flight } from './flight.models';
+import * as moment from 'moment';
 
 const augury = new MockHalService();
 
@@ -91,8 +92,8 @@ export const flightFixture: Flight = {
   id: 9,
   createdAt: new Date(),
   name: 'my flight name',
-  startAt: new Date('2019-10-01'),
-  endAt: new Date('2019-11-01'),
+  startAt: moment.utc('2019-10-01'),
+  endAt: moment.utc('2019-11-01'),
   totalGoal: 999,
   dailyMinimum: 99,
   zones: [{ id: 'pre_1', label: 'Preroll 1' }],
@@ -123,8 +124,8 @@ export const createFlightsState = campaignDoc => ({
 
 export const allocationPreviewParamsFixture = {
   flightId: flightFixture.id,
-  startAt: flightFixture.startAt,
-  endAt: flightFixture.endAt,
+  startAt: flightFixture.startAt.toDate(),
+  endAt: flightFixture.endAt.toDate(),
   name: flightFixture.name,
   set_inventory_uri: flightFixture.set_inventory_uri,
   zones: flightFixture.zones.map(zone => ({ id: zone.id })),
@@ -181,8 +182,8 @@ export const createAllocationPreviewState = () => ({
 
 export const availabilityParamsFixture = {
   inventoryId: flightFixture.set_inventory_uri.split('/').pop(),
-  startDate: flightFixture.startAt,
-  endDate: flightFixture.endAt,
+  startDate: flightFixture.startAt.toDate(),
+  endDate: flightFixture.endAt.toDate(),
   zone: flightFixture.zones[0].id,
   flightId: flightFixture.id
 };

--- a/src/app/campaign/store/models/combined.models.ts
+++ b/src/app/campaign/store/models/combined.models.ts
@@ -8,4 +8,5 @@ export interface CampaignFormSave {
   updatedFlights: Flight[];
   createdFlights: Flight[];
   deletedFlights: Flight[];
+  tempDeletedFlights: Flight[];
 }

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -1,6 +1,7 @@
 import { HalDoc } from 'ngx-prx-styleguide';
 import { filterUnderscores } from './haldoc.utils';
-
+import { Moment, utc } from 'moment';
+import { MomentDateAdapter } from '@angular/material-moment-adapter';
 export interface FlightZone {
   id: string;
   label?: string;
@@ -12,8 +13,8 @@ export interface FlightZone {
 export interface Flight {
   id?: number;
   name: string;
-  startAt: Date;
-  endAt: Date;
+  startAt: Moment;
+  endAt: Moment;
   set_inventory_uri: string;
   zones: FlightZone[];
   totalGoal: number;
@@ -34,8 +35,8 @@ export interface FlightState {
 
 export const docToFlight = (doc: HalDoc): Flight => {
   const flight = filterUnderscores(doc) as Flight;
-  flight.startAt = new Date(flight.startAt);
-  flight.endAt = new Date(flight.endAt);
+  flight.startAt = utc(flight.startAt);
+  flight.endAt = utc(flight.endAt);
   flight.createdAt = new Date(flight.createdAt);
   flight.set_inventory_uri = doc.expand('prx:inventory');
   return flight;
@@ -54,4 +55,25 @@ export const duplicateFlight = (flight: Flight, tempId: number): Flight => {
 
 export const getFlightId = (state: FlightState) => {
   return state.localFlight && state.localFlight.id;
+};
+
+export const isNameChanged = ({ name: compare }: { name: string }, { name: base }: { name: string }) => compare !== base;
+export const isInventoryChanged = (
+  { set_inventory_uri: compare }: { set_inventory_uri: string },
+  { set_inventory_uri: base }: { set_inventory_uri: string }
+) => compare !== base;
+const dateToString = (date: Moment) => date && date.valueOf();
+export const isStartAtChanged = ({ startAt: compare }: { startAt: Moment }, { startAt: base }: { startAt: Moment }) =>
+  dateToString(compare) !== dateToString(base);
+export const isEndAtChanged = ({ endAt: compare }: { endAt: Moment }, { endAt: base }: { endAt: Moment }) =>
+  dateToString(compare) !== dateToString(base);
+export const isZonesChanged = ({ zones: compare }: { zones: FlightZone[] }, { zones: base }: { zones: FlightZone[] }): boolean => {
+  const zonesToString = (zs: FlightZone[]) =>
+    zs &&
+    zs.length &&
+    zs
+      .map(z => `${z.id}${z.url || ''}`)
+      .sort((a, b) => a.localeCompare(b))
+      .join(',');
+  return zonesToString(compare) !== zonesToString(base);
 };

--- a/src/app/campaign/store/reducers/allocation-preview.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/allocation-preview.reducer.spec.ts
@@ -28,8 +28,8 @@ describe('Allocation Preview Reducer', () => {
         createdAt: new Date(),
         set_inventory_uri,
         name,
-        startAt,
-        endAt,
+        startAt: startAt.toDate(),
+        endAt: endAt.toDate(),
         totalGoal,
         dailyMinimum: 12,
         zones: zones.map(zone => ({ id: zone.id }))

--- a/src/app/campaign/store/reducers/campaign.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/campaign.reducer.spec.ts
@@ -106,6 +106,7 @@ describe('Campaign Reducer', () => {
         campaign: campaignFixture,
         campaignDoc: new MockHalDoc(campaignDocFixture),
         deletedFlights: [],
+        tempDeletedFlights: [],
         updatedFlights: [flightFixture],
         createdFlights: []
       })

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -3,6 +3,7 @@ import * as campaignActions from '../actions/campaign-action.creator';
 import { campaignDocFixture, flightFixture, flightDocFixture, createFlightsState, campaignFixture } from '../models/campaign-state.factory';
 import { reducer, initialState, selectAll, selectEntities, selectIds } from './flight.reducer';
 import { docToFlight, Flight } from '../models';
+import * as moment from 'moment';
 
 describe('Flight Reducer', () => {
   describe('unknown action', () => {
@@ -33,16 +34,16 @@ describe('Flight Reducer', () => {
   });
 
   it('should create a new flight', () => {
-    const date = new Date();
-    const startAt = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-    const endAt = new Date(Date.UTC(date.getFullYear(), date.getMonth() + 1, 1));
-    const result = reducer(initialState, new campaignActions.CampaignAddFlightWithTempId({ flightId: date.getTime(), startAt, endAt }));
+    const result = reducer(initialState, new campaignActions.CampaignAddFlight({ campaignId: campaignFixture.id }));
     const newFlight = selectAll(result).find(flight => !flight.remoteFlight);
     expect(newFlight.localFlight.name).toContain('New Flight');
   });
 
   it('should duplicate a flight', () => {
-    const result = reducer(initialState, new campaignActions.CampaignDupFlightWithTempId({ flightId: Date.now(), flight: flightFixture }));
+    const result = reducer(
+      initialState,
+      new campaignActions.CampaignDupFlight({ campaignId: campaignFixture.id, flightId: Date.now(), flight: flightFixture })
+    );
     const dupFlight = selectAll(result).find(flight => flight.localFlight.name.indexOf('(Copy)') > -1);
     expect(dupFlight.localFlight.zones).toBe(flightFixture.zones);
   });
@@ -124,8 +125,8 @@ describe('Flight Reducer', () => {
     const updatedFlightIds = [flightDocFixture.id + 2, flightDocFixture.id + 3];
     const createdFlightIds = [flightDocFixture.id + 4, flightDocFixture.id + 5];
     const newFlightIds = [Date.now(), Date.now() + 1];
-    const startAt = new Date();
-    const endAt = new Date();
+    const startAt = moment.utc();
+    const endAt = moment.utc();
 
     const campaignDoc = new MockHalDoc(campaignDocFixture);
     const flightDocs = [
@@ -140,8 +141,14 @@ describe('Flight Reducer', () => {
     ];
 
     let result = reducer(initialState, new campaignActions.CampaignLoadSuccess({ campaignDoc, flightDocs }));
-    result = reducer(result, new campaignActions.CampaignAddFlightWithTempId({ flightId: newFlightIds[0], startAt, endAt }));
-    result = reducer(result, new campaignActions.CampaignAddFlightWithTempId({ flightId: newFlightIds[1], startAt, endAt }));
+    result = reducer(
+      result,
+      new campaignActions.CampaignAddFlight({ campaignId: campaignFixture.id, flightId: newFlightIds[0], startAt, endAt })
+    );
+    result = reducer(
+      result,
+      new campaignActions.CampaignAddFlight({ campaignId: campaignFixture.id, flightId: newFlightIds[1], startAt, endAt })
+    );
     result = reducer(
       result,
       new campaignActions.CampaignSaveSuccess({

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -120,6 +120,25 @@ describe('Flight Reducer', () => {
     expect(result.entities[flightFixture.id].localFlight.dailyMinimum).toBe(99);
   });
 
+  it('should delete temporary softDeleted flights from save action', () => {
+    const flightId = Date.now();
+    let state = reducer(initialState, new campaignActions.CampaignAddFlight({ campaignId: campaignFixture.id, flightId }));
+    state = reducer(state, new campaignActions.CampaignAddFlight({ campaignId: campaignFixture.id, flightId: flightId + 1 }));
+    state = reducer(
+      state,
+      new campaignActions.CampaignSave({
+        campaign: campaignFixture,
+        campaignDoc: new MockHalDoc(campaignDocFixture),
+        deletedFlights: [],
+        updatedFlights: [],
+        createdFlights: [],
+        tempDeletedFlights: [state.entities[flightId].localFlight]
+      })
+    );
+    expect(state.entities[flightId]).toBeUndefined();
+    expect(state.entities[flightId + 1]).toBeDefined();
+  });
+
   it('should update flights from campaign save action', () => {
     const deletedFlightIds = [flightDocFixture.id, flightDocFixture.id + 1];
     const updatedFlightIds = [flightDocFixture.id + 2, flightDocFixture.id + 3];

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -98,7 +98,10 @@ export function reducer(state = initialState, action: CampaignActions): State {
           id: flight.id,
           changes: {
             localFlight,
-            changed: state.entities[flight.id].changed || changed,
+            // changed _should_ always be true on form updates
+            // however, we're seeing updates emit from the form when the form is not dirty (changed: false)
+            // so changed state shall be false until true
+            changed: (state.entities[flight.id] && state.entities[flight.id].changed) || changed,
             valid
           }
         },
@@ -112,6 +115,12 @@ export function reducer(state = initialState, action: CampaignActions): State {
           id,
           changes: { localFlight: { ...state.entities[id].localFlight, totalGoal, dailyMinimum: dailyMinimum || 0 }, changed: true, valid }
         },
+        state
+      );
+    }
+    case ActionTypes.CAMPAIGN_SAVE: {
+      return adapter.removeMany(
+        action.payload.tempDeletedFlights.map(flight => flight.id),
         state
       );
     }

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -98,7 +98,7 @@ export function reducer(state = initialState, action: CampaignActions): State {
           id: flight.id,
           changes: {
             localFlight,
-            changed,
+            changed: state.entities[flight.id].changed || changed,
             valid
           }
         },

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -64,7 +64,7 @@ export function reducer(state = initialState, action: CampaignActions): State {
       });
       return adapter.addAll(flights, state);
     }
-    case ActionTypes.CAMPAIGN_ADD_FLIGHT_WITH_TEMP_ID: {
+    case ActionTypes.CAMPAIGN_ADD_FLIGHT: {
       const { flightId: id, startAt, endAt } = action.payload;
       const initialFlightState: FlightState = {
         localFlight: {
@@ -81,9 +81,9 @@ export function reducer(state = initialState, action: CampaignActions): State {
       };
       return adapter.addOne(initialFlightState, state);
     }
-    case ActionTypes.CAMPAIGN_DUP_FLIGHT_WITH_TEMP_ID: {
-      const { flight, flightId: id } = action.payload;
-      const localFlight: Flight = { ...flight, id, name: `${flight.name} (Copy)` };
+    case ActionTypes.CAMPAIGN_DUP_FLIGHT: {
+      const { flight, flightId } = action.payload;
+      const localFlight: Flight = duplicateFlight({ ...flight, name: `${flight.name} (Copy)` }, flightId);
       return adapter.addOne({ localFlight, changed: true, valid: true }, state);
     }
     case ActionTypes.CAMPAIGN_DELETE_FLIGHT: {

--- a/src/app/campaign/store/selectors/campaign-flight.selectors.ts
+++ b/src/app/campaign/store/selectors/campaign-flight.selectors.ts
@@ -13,7 +13,8 @@ export const selectCampaignWithFlightsForSave = createSelector(
       .filter(flight => !flight.softDeleted && flight.changed && flight.remoteFlight)
       .map(flight => flight.localFlight),
     createdFlights: flights.filter(flight => !flight.softDeleted && !flight.remoteFlight).map(flight => flight.localFlight),
-    deletedFlights: flights.filter(flight => flight.softDeleted && flight.remoteFlight).map(flight => flight.localFlight)
+    deletedFlights: flights.filter(flight => flight.softDeleted && flight.remoteFlight).map(flight => flight.localFlight),
+    tempDeletedFlights: flights.filter(flight => flight.softDeleted && !flight.remoteFlight).map(flight => flight.localFlight)
   })
 );
 
@@ -21,7 +22,7 @@ export const selectValid = createSelector(
   selectCampaign,
   selectAllFlights,
   (campaignState: CampaignState, flightsState: FlightState[]): boolean =>
-    campaignState.valid && flightsState.every(flight => (flight.valid && !!flight.localFlight.totalGoal) || flight.softDeleted)
+    campaignState.valid && flightsState.every(flight => flight.valid || flight.softDeleted)
 );
 
 export const selectChanged = createSelector(

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,6 +185,13 @@
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-7.2.15.tgz#b2ba33e472dc5e530047c408ff7a35deba4427b8"
   integrity sha512-Ig5Jr7mnDelaZvSbUd9YhI5am3q1ku9xelAuwvtyDKvQJeKQj3BtTagcOgWrnQBfrJ/FsA/M5Zo48ncSsV0tqQ==
 
+"@angular/material-moment-adapter@~7.3.7":
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/@angular/material-moment-adapter/-/material-moment-adapter-7.3.7.tgz#8ad991a1035764fffc5a433dc4038e2ea8c93104"
+  integrity sha512-Nb8hZkF6zcni7Jb+FXcTKKmbp8PhhFAhJSkch9FnKcFs1Py+sCNTLIH/cI53nPrTglkJwlVLwMW7fxj4w9I1CQ==
+  dependencies:
+    tslib "^1.7.1"
+
 "@angular/material@~7.3.7":
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/@angular/material/-/material-7.3.7.tgz#dcd95e6618ba6254c5880efee1aad349cf5b9140"


### PR DESCRIPTION
* Bandaid on the Flight Form
  * The boolean guard in wrapping updateFlightForm was no longer doing it. On form valueChanges, I added a check on the fields to see if they changed before emit. 
  * This would _almost do it, but I still saw some updates where the form wasn't dirty that cleared the flight changed status. So there's another fix in the flight.reducer to have changed: false until true on form updates. Changed will be cleared/false on Save.
* Uses the Material Datepicker and uses the MomentDateAdapter with UTC support.
  * Turns out the MomentDateAdapter must be configured in the app.module or it won't take effect
  * This changes the Flight startAt/endAt fields to be Moment instead of native Date. I've rethought this and wondered if I should have just kept Moment in the form, but oh well.
* Cleaned up the Add and Duplicate Flight actions to generate flightId/timestamp in the action creator. The effects don't have a subsequent action and just handle nagivation.
* Spotted a bug where temporary/unsaved flights were not removed on Save if they were softDeleted
* Fixed another bug where duplicated flights were getting an error from availability because it was sending the temp flightId. It's expected that unsaved flights should not have createdAt, fixed.
