### PR TITLE
inventory table changes

### DIFF
--- a/src/app/campaign/availability/availability.component.scss
+++ b/src/app/campaign/availability/availability.component.scss
@@ -34,6 +34,16 @@ section {
     border-top: $row-divider-border;
   }
 
+  & + &.current-date,
+  &.current-date {
+    border-top: 1px solid mat-color($prx-primary, lighter);
+  }
+
+  &.past-date * {
+    color: mat-color($prx-neutral, default);
+    font-weight: 700;
+  }
+
   &.head {
     background-color: prx-theme-background(table-header);
 
@@ -139,8 +149,6 @@ section {
 }
 
 .preview {
-  color: $success;
-
   &::after {
     content: '*';
   }

--- a/src/app/campaign/availability/availability.component.spec.ts
+++ b/src/app/campaign/availability/availability.component.spec.ts
@@ -173,10 +173,6 @@ describe('AvailabilityComponent', () => {
     expect(comp.getAllocationValue(week.numbers)).toEqual(week.numbers.allocationPreview);
   });
 
-  it('should return combined value of allocated and availability', () => {
-    expect(comp.getAvailableValue(week.numbers)).toEqual(week.numbers.allocated + week.numbers.availability);
-  });
-
   it('should show a week as the current week when not expanded', () => {
     expect(comp.isZoneWeekExpanded(mockRollup, week)).toBeFalsy();
     expect(comp.showAsCurrentWeek(mockRollup, week)).toBeFalsy();

--- a/src/app/campaign/availability/availability.component.spec.ts
+++ b/src/app/campaign/availability/availability.component.spec.ts
@@ -24,31 +24,31 @@ describe('AvailabilityComponent', () => {
       {
         startDate: new Date('2019-10-01'),
         endDate: new Date('2019-10-05'),
-        numbers: { allocated: 1, availability: 1, actuals: 0, allocationPreview: 3 },
+        numbers: { allocated: 1, availability: 2, actuals: 0, allocationPreview: 3 },
         days: []
       },
       {
         startDate: new Date('2019-10-06'),
         endDate: new Date('2019-10-12'),
-        numbers: { allocated: 9, availability: 1339, actuals: 0, allocationPreview: 9 },
+        numbers: { allocated: 9, availability: 1348, actuals: 0, allocationPreview: 9 },
         days: []
       },
       {
         startDate: new Date('2019-10-13'),
         endDate: new Date('2019-10-19'),
-        numbers: { allocated: 8, availability: 8, actuals: 0, allocationPreview: 8 },
+        numbers: { allocated: 8, availability: 16, actuals: 0, allocationPreview: 8 },
         days: []
       },
       {
         startDate: new Date('2019-10-20'),
         endDate: new Date('2019-10-26'),
-        numbers: { allocated: 7, availability: 1393, actuals: 0, allocationPreview: 7 },
+        numbers: { allocated: 7, availability: 1400, actuals: 0, allocationPreview: 7 },
         days: []
       },
       {
         startDate: new Date('2019-10-27'),
         endDate: new Date('2019-10-31'),
-        numbers: { allocated: 6, availability: 722, actuals: 0, allocationPreview: 6 },
+        numbers: { allocated: 6, availability: 728, actuals: 0, allocationPreview: 6 },
         days: []
       }
     ]
@@ -158,7 +158,7 @@ describe('AvailabilityComponent', () => {
 
   it('should return truthy when preview exceeds available', () => {
     expect(comp.allocationPreviewExceedsAvailable(week.numbers)).toBeTruthy();
-    expect(comp.allocationPreviewExceedsAvailable({ ...week.numbers, allocated: 9 })).toBeFalsy();
+    expect(comp.allocationPreviewExceedsAvailable({ ...week.numbers, allocationPreview: week.numbers.availability - 1 })).toBeFalsy();
   });
 
   it('should return truthy when preview allocations exist after change', () => {
@@ -175,5 +175,18 @@ describe('AvailabilityComponent', () => {
 
   it('should return combined value of allocated and availability', () => {
     expect(comp.getAvailableValue(week.numbers)).toEqual(week.numbers.allocated + week.numbers.availability);
+  });
+
+  it('should show a week as the current week when not expanded', () => {
+    expect(comp.isZoneWeekExpanded(mockRollup, week)).toBeFalsy();
+    expect(comp.showAsCurrentWeek(mockRollup, week)).toBeFalsy();
+  });
+
+  it('should show a date in the past', () => {
+    expect(comp.showAsPastDate(new Date('2019-12-31'))).toBeTruthy();
+  });
+
+  it('should show a date as the current date', () => {
+    expect(comp.showAsCurrentDate(new Date())).toBeTruthy();
   });
 });

--- a/src/app/campaign/availability/availability.component.ts
+++ b/src/app/campaign/availability/availability.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter } from '@angular/core';
 import { InventoryZone } from '../../core';
 import { Flight, AvailabilityRollup, AvailabilityWeeklyRollup, AvailabilityParams, InventoryNumbers } from '../store/models';
+import { getMidnightUTC } from '../store/selectors';
 
 @Component({
   selector: 'grove-availability',
@@ -30,6 +31,8 @@ import { Flight, AvailabilityRollup, AvailabilityWeeklyRollup, AvailabilityParam
             class="row week"
             [class.row-highlight]="allocationPreviewExceedsAvailable(week.numbers)"
             [class.expanded]="isZoneWeekExpanded(rollup, week)"
+            [class.current-date]="showAsCurrentWeek(rollup, week)"
+            [class.past-date]="showAsPastDate(week.endDate)"
           >
             <div class="expand">
               <button class="btn-link" (click)="toggleZoneWeekExpanded(rollup, week)">
@@ -39,7 +42,7 @@ import { Flight, AvailabilityRollup, AvailabilityWeeklyRollup, AvailabilityParam
             <div class="date">
               {{ week.startDate | date: 'M/dd':'+0000' }}
             </div>
-            <div>{{ getAvailableValue(week.numbers) | largeNumber }}</div>
+            <div>{{ week.numbers.availability | largeNumber }}</div>
             <div [class.preview]="hasAllocationPreviewAfterChange(week.numbers.allocationPreview)">
               {{ getAllocationValue(week.numbers) | largeNumber }}
             </div>
@@ -53,13 +56,19 @@ import { Flight, AvailabilityRollup, AvailabilityWeeklyRollup, AvailabilityParam
             </div>
             <div class="days-wrapper">
               <div class="days" [cssProps]="{ '--num-days': week?.days?.length }">
-                <div class="row day" [class.row-highlight]="allocationPreviewExceedsAvailable(day.numbers)" *ngFor="let day of week.days">
+                <div
+                  *ngFor="let day of week.days"
+                  class="row day"
+                  [class.row-highlight]="allocationPreviewExceedsAvailable(day.numbers)"
+                  [class.current-date]="showAsCurrentDate(day.date)"
+                  [class.past-date]="showAsPastDate(day.date)"
+                >
                   <div class="expand"></div>
                   <div class="date">
                     <span>{{ day.date | date: 'M/dd':'+0000' }}</span>
                   </div>
                   <div class="avail">
-                    <span>{{ getAvailableValue(day.numbers) | largeNumber }}</span>
+                    <span>{{ day.numbers.availability | largeNumber }}</span>
                   </div>
                   <div class="goal" [class.preview]="hasAllocationPreviewAfterChange(day.numbers.allocationPreview)">
                     <span>{{ getAllocationValue(day.numbers) | largeNumber }}</span>
@@ -76,7 +85,7 @@ import { Flight, AvailabilityRollup, AvailabilityWeeklyRollup, AvailabilityParam
         <div class="row totals" [class.row-highlight]="allocationPreviewExceedsAvailable(rollup.totals)">
           <div class="expand"></div>
           <div class="date">TOTALS</div>
-          <div>{{ getAvailableValue(rollup.totals) | largeNumber }}</div>
+          <div>{{ rollup.totals.availability | largeNumber }}</div>
           <div [class.preview]="hasAllocationPreviewAfterChange(rollup.totals.allocationPreview)">
             {{ getAllocationValue(rollup.totals) | largeNumber }}
           </div>
@@ -124,6 +133,18 @@ export class AvailabilityComponent {
     this.zoneWeekExpanded[zoneWeekKey] = !this.zoneWeekExpanded[zoneWeekKey];
   }
 
+  showAsCurrentWeek(rollup: AvailabilityRollup, week: AvailabilityWeeklyRollup): boolean {
+    return !this.isZoneWeekExpanded(rollup, week) && week.startDate.valueOf() <= Date.now() && week.endDate.valueOf() >= Date.now();
+  }
+
+  showAsCurrentDate(date: Date): boolean {
+    return getMidnightUTC(new Date()) === getMidnightUTC(date);
+  }
+
+  showAsPastDate(date: Date): boolean {
+    return getMidnightUTC(date) < getMidnightUTC(new Date());
+  }
+
   cantShowInventory() {
     return (
       !this.flight ||
@@ -155,8 +176,7 @@ export class AvailabilityComponent {
     return allocated + availability;
   }
 
-  allocationPreviewExceedsAvailable(numbers: InventoryNumbers): boolean {
-    const { allocationPreview } = numbers;
-    return this.getAvailableValue(numbers) < allocationPreview;
+  allocationPreviewExceedsAvailable({ availability, allocationPreview }: InventoryNumbers): boolean {
+    return availability < allocationPreview;
   }
 }

--- a/src/app/campaign/availability/availability.component.ts
+++ b/src/app/campaign/availability/availability.component.ts
@@ -172,10 +172,6 @@ export class AvailabilityComponent {
     return zone && zone.label;
   }
 
-  getAvailableValue({ allocated, availability }: InventoryNumbers): number {
-    return allocated + availability;
-  }
-
   allocationPreviewExceedsAvailable({ availability, allocationPreview }: InventoryNumbers): boolean {
     return availability < allocationPreview;
   }

--- a/src/app/campaign/store/models/allocation-preview.models.ts
+++ b/src/app/campaign/store/models/allocation-preview.models.ts
@@ -1,4 +1,5 @@
 import { HalDoc } from 'ngx-prx-styleguide';
+import * as moment from 'moment';
 
 export interface AllocationPreview {
   date: Date;
@@ -10,15 +11,15 @@ export interface AllocationPreview {
 export const docToAllocationPreviewParams = (doc: HalDoc) => ({
   ...(doc['id'] && { flightId: doc['id'] }),
   dailyMinimum: doc['dailyMinimum'],
-  startAt: new Date(doc['startAt']),
-  endAt: new Date(doc['endAt']),
+  startAt: moment.utc(doc['startAt']).toDate(),
+  endAt: moment.utc(doc['endAt']).toDate(),
   name: doc['name'],
   totalGoal: doc['totalGoal'],
   zones: doc['zones'] || []
 });
 
 export const docToAllocationPreview = (allocation: any): AllocationPreview => {
-  const date = new Date(allocation.date);
+  const date = moment.utc(allocation.date).toDate();
   return {
     date,
     goalCount: allocation.goalCount,

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -133,39 +133,48 @@ export const allocationPreviewParamsFixture = {
   totalGoal: flightFixture.totalGoal
 };
 
-export const allocationPreviewData: any[] = [
-  { goalCount: 28, inventoryDayId: 6553, date: '2019-10-01', zoneName: 'pre_1' },
-  { goalCount: 16, inventoryDayId: 6560, date: '2019-10-02', zoneName: 'pre_1' },
-  { goalCount: 8, inventoryDayId: 6567, date: '2019-10-03', zoneName: 'pre_1' },
-  { goalCount: 4, inventoryDayId: 6574, date: '2019-10-04', zoneName: 'pre_1' },
-  { goalCount: 3, inventoryDayId: 6581, date: '2019-10-05', zoneName: 'pre_1' },
-  { goalCount: 184, inventoryDayId: 6588, date: '2019-10-06', zoneName: 'pre_1' },
-  { goalCount: 85, inventoryDayId: 6595, date: '2019-10-07', zoneName: 'pre_1' },
-  { goalCount: 36, inventoryDayId: 6602, date: '2019-10-08', zoneName: 'pre_1' },
-  { goalCount: 20, inventoryDayId: 6609, date: '2019-10-09', zoneName: 'pre_1' },
-  { goalCount: 9, inventoryDayId: 6616, date: '2019-10-10', zoneName: 'pre_1' },
-  { goalCount: 4, inventoryDayId: 6623, date: '2019-10-11', zoneName: 'pre_1' },
-  { goalCount: 2, inventoryDayId: 6630, date: '2019-10-12', zoneName: 'pre_1' },
-  { goalCount: 1, inventoryDayId: 6637, date: '2019-10-13', zoneName: 'pre_1' },
-  { goalCount: 1, inventoryDayId: 6644, date: '2019-10-14', zoneName: 'pre_1' },
-  { goalCount: 1, inventoryDayId: 6651, date: '2019-10-15', zoneName: 'pre_1' },
-  { goalCount: 1, inventoryDayId: 6658, date: '2019-10-16', zoneName: 'pre_1' },
-  { goalCount: 1, inventoryDayId: 6665, date: '2019-10-17', zoneName: 'pre_1' },
-  { goalCount: 163, inventoryDayId: 6672, date: '2019-10-18', zoneName: 'pre_1' },
-  { goalCount: 82, inventoryDayId: 6679, date: '2019-10-19', zoneName: 'pre_1' },
-  { goalCount: 33, inventoryDayId: 6686, date: '2019-10-20', zoneName: 'pre_1' },
-  { goalCount: 15, inventoryDayId: 6693, date: '2019-10-21', zoneName: 'pre_1' },
-  { goalCount: 7, inventoryDayId: 6700, date: '2019-10-22', zoneName: 'pre_1' },
-  { goalCount: 4, inventoryDayId: 6707, date: '2019-10-23', zoneName: 'pre_1' },
-  { goalCount: 2, inventoryDayId: 6714, date: '2019-10-24', zoneName: 'pre_1' },
-  { goalCount: 164, inventoryDayId: 6721, date: '2019-10-25', zoneName: 'pre_1' },
-  { goalCount: 71, inventoryDayId: 6728, date: '2019-10-26', zoneName: 'pre_1' },
-  { goalCount: 29, inventoryDayId: 6735, date: '2019-10-27', zoneName: 'pre_1' },
-  { goalCount: 14, inventoryDayId: 6742, date: '2019-10-28', zoneName: 'pre_1' },
-  { goalCount: 7, inventoryDayId: 6749, date: '2019-10-29', zoneName: 'pre_1' },
-  { goalCount: 3, inventoryDayId: 6756, date: '2019-10-30', zoneName: 'pre_1' },
-  { goalCount: 1, inventoryDayId: 6763, date: '2019-10-31', zoneName: 'pre_1' }
-];
+export const allocationPreviewData: any[] = new Array(30).fill(null).map((_, i) => ({
+  goalCount: Math.floor(Math.random() * 100),
+  zoneName: 'pre_1',
+  date: moment
+    .utc()
+    .add(i - 15, 'days')
+    .toISOString()
+    .slice(0, 10)
+}));
+// [
+//   { goalCount: 28, inventoryDayId: 6553, date: '2019-10-01', zoneName: 'pre_1' },
+//   { goalCount: 16, inventoryDayId: 6560, date: '2019-10-02', zoneName: 'pre_1' },
+//   { goalCount: 8, inventoryDayId: 6567, date: '2019-10-03', zoneName: 'pre_1' },
+//   { goalCount: 4, inventoryDayId: 6574, date: '2019-10-04', zoneName: 'pre_1' },
+//   { goalCount: 3, inventoryDayId: 6581, date: '2019-10-05', zoneName: 'pre_1' },
+//   { goalCount: 184, inventoryDayId: 6588, date: '2019-10-06', zoneName: 'pre_1' },
+//   { goalCount: 85, inventoryDayId: 6595, date: '2019-10-07', zoneName: 'pre_1' },
+//   { goalCount: 36, inventoryDayId: 6602, date: '2019-10-08', zoneName: 'pre_1' },
+//   { goalCount: 20, inventoryDayId: 6609, date: '2019-10-09', zoneName: 'pre_1' },
+//   { goalCount: 9, inventoryDayId: 6616, date: '2019-10-10', zoneName: 'pre_1' },
+//   { goalCount: 4, inventoryDayId: 6623, date: '2019-10-11', zoneName: 'pre_1' },
+//   { goalCount: 2, inventoryDayId: 6630, date: '2019-10-12', zoneName: 'pre_1' },
+//   { goalCount: 1, inventoryDayId: 6637, date: '2019-10-13', zoneName: 'pre_1' },
+//   { goalCount: 1, inventoryDayId: 6644, date: '2019-10-14', zoneName: 'pre_1' },
+//   { goalCount: 1, inventoryDayId: 6651, date: '2019-10-15', zoneName: 'pre_1' },
+//   { goalCount: 1, inventoryDayId: 6658, date: '2019-10-16', zoneName: 'pre_1' },
+//   { goalCount: 1, inventoryDayId: 6665, date: '2019-10-17', zoneName: 'pre_1' },
+//   { goalCount: 163, inventoryDayId: 6672, date: '2019-10-18', zoneName: 'pre_1' },
+//   { goalCount: 82, inventoryDayId: 6679, date: '2019-10-19', zoneName: 'pre_1' },
+//   { goalCount: 33, inventoryDayId: 6686, date: '2019-10-20', zoneName: 'pre_1' },
+//   { goalCount: 15, inventoryDayId: 6693, date: '2019-10-21', zoneName: 'pre_1' },
+//   { goalCount: 7, inventoryDayId: 6700, date: '2019-10-22', zoneName: 'pre_1' },
+//   { goalCount: 4, inventoryDayId: 6707, date: '2019-10-23', zoneName: 'pre_1' },
+//   { goalCount: 2, inventoryDayId: 6714, date: '2019-10-24', zoneName: 'pre_1' },
+//   { goalCount: 164, inventoryDayId: 6721, date: '2019-10-25', zoneName: 'pre_1' },
+//   { goalCount: 71, inventoryDayId: 6728, date: '2019-10-26', zoneName: 'pre_1' },
+//   { goalCount: 29, inventoryDayId: 6735, date: '2019-10-27', zoneName: 'pre_1' },
+//   { goalCount: 14, inventoryDayId: 6742, date: '2019-10-28', zoneName: 'pre_1' },
+//   { goalCount: 7, inventoryDayId: 6749, date: '2019-10-29', zoneName: 'pre_1' },
+//   { goalCount: 3, inventoryDayId: 6756, date: '2019-10-30', zoneName: 'pre_1' },
+//   { goalCount: 1, inventoryDayId: 6763, date: '2019-10-31', zoneName: 'pre_1' }
+// ];
 export const allocationPreviewFixture: AllocationPreview[] = allocationPreviewData.map(allocation => docToAllocationPreview(allocation));
 export const allocationPreviewEntities: Dictionary<AllocationPreview> = allocationPreviewFixture.reduce(
   (acc, allocation) => ({ ...acc, [selectAllocationPreviewId(allocation)]: allocation }),
@@ -187,39 +196,49 @@ export const availabilityParamsFixture = {
   zone: flightFixture.zones[0].id,
   flightId: flightFixture.id
 };
-export const availabilityData = [
-  { allocated: null, availability: 1, date: '2019-10-01' },
-  { allocated: null, availability: 0, date: '2019-10-02' },
-  { allocated: 0, availability: 9858, date: '2019-10-03' },
-  { allocated: 0, availability: 5305, date: '2019-10-04' },
-  { allocated: 0, availability: 2387, date: '2019-10-05' },
-  { allocated: 0, availability: 1339, date: '2019-10-06' },
-  { allocated: 0, availability: 709, date: '2019-10-07' },
-  { allocated: 0, availability: 357, date: '2019-10-08' },
-  { allocated: 0, availability: 158, date: '2019-10-09' },
-  { allocated: 0, availability: 85, date: '2019-10-10' },
-  { allocated: 0, availability: 48, date: '2019-10-11' },
-  { allocated: 0, availability: 19, date: '2019-10-12' },
-  { allocated: 0, availability: 8, date: '2019-10-13' },
-  { allocated: 0, availability: 4, date: '2019-10-14' },
-  { allocated: 0, availability: 1, date: '2019-10-15' },
-  { allocated: 0, availability: 10812, date: '2019-10-16' },
-  { allocated: 0, availability: 5299, date: '2019-10-17' },
-  { allocated: 0, availability: 2527, date: '2019-10-18' },
-  { allocated: 0, availability: 1393, date: '2019-10-19' },
-  { allocated: 0, availability: 722, date: '2019-10-20' },
-  { allocated: 0, availability: 430, date: '2019-10-21' },
-  { allocated: 0, availability: 237, date: '2019-10-22' },
-  { allocated: 0, availability: 97, date: '2019-10-23' },
-  { allocated: 0, availability: 10333, date: '2019-10-24' },
-  { allocated: 0, availability: 6174, date: '2019-10-25' },
-  { allocated: 0, availability: 3567, date: '2019-10-26' },
-  { allocated: 0, availability: 1691, date: '2019-10-27' },
-  { allocated: 0, availability: 765, date: '2019-10-28' },
-  { allocated: 0, availability: 403, date: '2019-10-29' },
-  { allocated: 0, availability: 182, date: '2019-10-30' },
-  { allocated: 0, availability: 91, date: '2019-10-31' }
-];
+export const availabilityData = new Array(30).fill(null).map((_, i) => ({
+  allocated: Math.floor(Math.random() * 100),
+  availability: Math.floor(Math.random() * 1000),
+  actuals: i < 15 ? Math.floor(Math.random() * 100) : 0,
+  date: moment
+    .utc()
+    .add(i - 15, 'days')
+    .toISOString()
+    .slice(0, 10)
+}));
+// [
+//   { allocated: null, availability: 1, date: '2019-10-01' },
+//   { allocated: null, availability: 0, date: '2019-10-02' },
+//   { allocated: 0, availability: 9858, date: '2019-10-03' },
+//   { allocated: 0, availability: 5305, date: '2019-10-04' },
+//   { allocated: 0, availability: 2387, date: '2019-10-05' },
+//   { allocated: 0, availability: 1339, date: '2019-10-06' },
+//   { allocated: 0, availability: 709, date: '2019-10-07' },
+//   { allocated: 0, availability: 357, date: '2019-10-08' },
+//   { allocated: 0, availability: 158, date: '2019-10-09' },
+//   { allocated: 0, availability: 85, date: '2019-10-10' },
+//   { allocated: 0, availability: 48, date: '2019-10-11' },
+//   { allocated: 0, availability: 19, date: '2019-10-12' },
+//   { allocated: 0, availability: 8, date: '2019-10-13' },
+//   { allocated: 0, availability: 4, date: '2019-10-14' },
+//   { allocated: 0, availability: 1, date: '2019-10-15' },
+//   { allocated: 0, availability: 10812, date: '2019-10-16' },
+//   { allocated: 0, availability: 5299, date: '2019-10-17' },
+//   { allocated: 0, availability: 2527, date: '2019-10-18' },
+//   { allocated: 0, availability: 1393, date: '2019-10-19' },
+//   { allocated: 0, availability: 722, date: '2019-10-20' },
+//   { allocated: 0, availability: 430, date: '2019-10-21' },
+//   { allocated: 0, availability: 237, date: '2019-10-22' },
+//   { allocated: 0, availability: 97, date: '2019-10-23' },
+//   { allocated: 0, availability: 10333, date: '2019-10-24' },
+//   { allocated: 0, availability: 6174, date: '2019-10-25' },
+//   { allocated: 0, availability: 3567, date: '2019-10-26' },
+//   { allocated: 0, availability: 1691, date: '2019-10-27' },
+//   { allocated: 0, availability: 765, date: '2019-10-28' },
+//   { allocated: 0, availability: 403, date: '2019-10-29' },
+//   { allocated: 0, availability: 182, date: '2019-10-30' },
+//   { allocated: 0, availability: 91, date: '2019-10-31' }
+// ];
 export const availabilityDaysFixture: AvailabilityDay[] = availabilityData.map(availability => docToAvailabilityDay(availability));
 export const availabilityEntities = {
   [`${availabilityParamsFixture.flightId}_${availabilityParamsFixture.zone}`]: {

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -142,39 +142,6 @@ export const allocationPreviewData: any[] = new Array(30).fill(null).map((_, i) 
     .toISOString()
     .slice(0, 10)
 }));
-// [
-//   { goalCount: 28, inventoryDayId: 6553, date: '2019-10-01', zoneName: 'pre_1' },
-//   { goalCount: 16, inventoryDayId: 6560, date: '2019-10-02', zoneName: 'pre_1' },
-//   { goalCount: 8, inventoryDayId: 6567, date: '2019-10-03', zoneName: 'pre_1' },
-//   { goalCount: 4, inventoryDayId: 6574, date: '2019-10-04', zoneName: 'pre_1' },
-//   { goalCount: 3, inventoryDayId: 6581, date: '2019-10-05', zoneName: 'pre_1' },
-//   { goalCount: 184, inventoryDayId: 6588, date: '2019-10-06', zoneName: 'pre_1' },
-//   { goalCount: 85, inventoryDayId: 6595, date: '2019-10-07', zoneName: 'pre_1' },
-//   { goalCount: 36, inventoryDayId: 6602, date: '2019-10-08', zoneName: 'pre_1' },
-//   { goalCount: 20, inventoryDayId: 6609, date: '2019-10-09', zoneName: 'pre_1' },
-//   { goalCount: 9, inventoryDayId: 6616, date: '2019-10-10', zoneName: 'pre_1' },
-//   { goalCount: 4, inventoryDayId: 6623, date: '2019-10-11', zoneName: 'pre_1' },
-//   { goalCount: 2, inventoryDayId: 6630, date: '2019-10-12', zoneName: 'pre_1' },
-//   { goalCount: 1, inventoryDayId: 6637, date: '2019-10-13', zoneName: 'pre_1' },
-//   { goalCount: 1, inventoryDayId: 6644, date: '2019-10-14', zoneName: 'pre_1' },
-//   { goalCount: 1, inventoryDayId: 6651, date: '2019-10-15', zoneName: 'pre_1' },
-//   { goalCount: 1, inventoryDayId: 6658, date: '2019-10-16', zoneName: 'pre_1' },
-//   { goalCount: 1, inventoryDayId: 6665, date: '2019-10-17', zoneName: 'pre_1' },
-//   { goalCount: 163, inventoryDayId: 6672, date: '2019-10-18', zoneName: 'pre_1' },
-//   { goalCount: 82, inventoryDayId: 6679, date: '2019-10-19', zoneName: 'pre_1' },
-//   { goalCount: 33, inventoryDayId: 6686, date: '2019-10-20', zoneName: 'pre_1' },
-//   { goalCount: 15, inventoryDayId: 6693, date: '2019-10-21', zoneName: 'pre_1' },
-//   { goalCount: 7, inventoryDayId: 6700, date: '2019-10-22', zoneName: 'pre_1' },
-//   { goalCount: 4, inventoryDayId: 6707, date: '2019-10-23', zoneName: 'pre_1' },
-//   { goalCount: 2, inventoryDayId: 6714, date: '2019-10-24', zoneName: 'pre_1' },
-//   { goalCount: 164, inventoryDayId: 6721, date: '2019-10-25', zoneName: 'pre_1' },
-//   { goalCount: 71, inventoryDayId: 6728, date: '2019-10-26', zoneName: 'pre_1' },
-//   { goalCount: 29, inventoryDayId: 6735, date: '2019-10-27', zoneName: 'pre_1' },
-//   { goalCount: 14, inventoryDayId: 6742, date: '2019-10-28', zoneName: 'pre_1' },
-//   { goalCount: 7, inventoryDayId: 6749, date: '2019-10-29', zoneName: 'pre_1' },
-//   { goalCount: 3, inventoryDayId: 6756, date: '2019-10-30', zoneName: 'pre_1' },
-//   { goalCount: 1, inventoryDayId: 6763, date: '2019-10-31', zoneName: 'pre_1' }
-// ];
 export const allocationPreviewFixture: AllocationPreview[] = allocationPreviewData.map(allocation => docToAllocationPreview(allocation));
 export const allocationPreviewEntities: Dictionary<AllocationPreview> = allocationPreviewFixture.reduce(
   (acc, allocation) => ({ ...acc, [selectAllocationPreviewId(allocation)]: allocation }),
@@ -206,39 +173,6 @@ export const availabilityData = new Array(30).fill(null).map((_, i) => ({
     .toISOString()
     .slice(0, 10)
 }));
-// [
-//   { allocated: null, availability: 1, date: '2019-10-01' },
-//   { allocated: null, availability: 0, date: '2019-10-02' },
-//   { allocated: 0, availability: 9858, date: '2019-10-03' },
-//   { allocated: 0, availability: 5305, date: '2019-10-04' },
-//   { allocated: 0, availability: 2387, date: '2019-10-05' },
-//   { allocated: 0, availability: 1339, date: '2019-10-06' },
-//   { allocated: 0, availability: 709, date: '2019-10-07' },
-//   { allocated: 0, availability: 357, date: '2019-10-08' },
-//   { allocated: 0, availability: 158, date: '2019-10-09' },
-//   { allocated: 0, availability: 85, date: '2019-10-10' },
-//   { allocated: 0, availability: 48, date: '2019-10-11' },
-//   { allocated: 0, availability: 19, date: '2019-10-12' },
-//   { allocated: 0, availability: 8, date: '2019-10-13' },
-//   { allocated: 0, availability: 4, date: '2019-10-14' },
-//   { allocated: 0, availability: 1, date: '2019-10-15' },
-//   { allocated: 0, availability: 10812, date: '2019-10-16' },
-//   { allocated: 0, availability: 5299, date: '2019-10-17' },
-//   { allocated: 0, availability: 2527, date: '2019-10-18' },
-//   { allocated: 0, availability: 1393, date: '2019-10-19' },
-//   { allocated: 0, availability: 722, date: '2019-10-20' },
-//   { allocated: 0, availability: 430, date: '2019-10-21' },
-//   { allocated: 0, availability: 237, date: '2019-10-22' },
-//   { allocated: 0, availability: 97, date: '2019-10-23' },
-//   { allocated: 0, availability: 10333, date: '2019-10-24' },
-//   { allocated: 0, availability: 6174, date: '2019-10-25' },
-//   { allocated: 0, availability: 3567, date: '2019-10-26' },
-//   { allocated: 0, availability: 1691, date: '2019-10-27' },
-//   { allocated: 0, availability: 765, date: '2019-10-28' },
-//   { allocated: 0, availability: 403, date: '2019-10-29' },
-//   { allocated: 0, availability: 182, date: '2019-10-30' },
-//   { allocated: 0, availability: 91, date: '2019-10-31' }
-// ];
 export const availabilityDaysFixture: AvailabilityDay[] = availabilityData.map(availability => docToAvailabilityDay(availability));
 export const availabilityEntities = {
   [`${availabilityParamsFixture.flightId}_${availabilityParamsFixture.zone}`]: {

--- a/src/app/campaign/store/selectors/availability-allocation-actuals.selectors.spec.ts
+++ b/src/app/campaign/store/selectors/availability-allocation-actuals.selectors.spec.ts
@@ -2,8 +2,31 @@ import * as campaignStateFactory from '../models/campaign-state.factory';
 import * as comboSelectors from './availability-allocation-actuals.selectors';
 import { AvailabilityRollup } from '../models';
 import { selectId as selectAllocationPreviewId } from '../reducers/allocation-preview.reducer';
+import { selectId as selectAvailabilityId } from '../reducers/availability.reducer';
+import * as moment from 'moment';
 
 describe('Availability-Allocation-Actuals Combination Selectors', () => {
+  const allocationPreviewState = campaignStateFactory.createAllocationPreviewState().allocationPreview;
+  it('should look up allocation preview by entity key', () => {
+    expect(
+      comboSelectors.getAllocationPreviewForDate(
+        new Date().toISOString().slice(0, 10),
+        allocationPreviewState.zones[0].id,
+        allocationPreviewState.entities
+      )
+    ).toBeDefined();
+    // remove first entry to select from entities with missingData
+    const missingDataKey = Object.keys(allocationPreviewState.entities)[0];
+    const { [missingDataKey]: missingData, ...withMissingData } = allocationPreviewState.entities;
+    expect(
+      comboSelectors.getAllocationPreviewForDate(
+        allocationPreviewState.entities[Object.keys(allocationPreviewState.entities)[0]].date.toISOString().slice(0, 10),
+        allocationPreviewState.zones[0].id,
+        withMissingData
+      )
+    ).toBeUndefined();
+  });
+
   it('should ignore missing allocation preview data', () => {
     // remove day 1 from entities
     const withMissingData = campaignStateFactory.allocationPreviewFixture
@@ -22,7 +45,36 @@ describe('Availability-Allocation-Actuals Combination Selectors', () => {
     );
   });
 
-  it('should roll up into weekly availability and includes allocation preview', () => {
+  it('should roll up into weekly availability+allocated and only include availability from current date forward', () => {
+    const rollups: AvailabilityRollup[] = comboSelectors.selectAvailabilityRollup.projector(
+      campaignStateFactory.availabilityEntities,
+      campaignStateFactory.allocationPreviewEntities,
+      campaignStateFactory.flightFixture.id,
+      campaignStateFactory.flightFixture.zones.map(z => z.id)
+    );
+
+    // data is 15 days back and 15 days ahead including today
+    // check the last week of data
+    const beginningOfLastWeek =
+      campaignStateFactory.availabilityDaysFixture.length -
+      (1 +
+        campaignStateFactory.availabilityDaysFixture
+          .slice()
+          .reverse()
+          .findIndex(day => moment.utc(day.date).day() === 0));
+    expect(rollups[0].weeks[rollups[0].weeks.length - 1].numbers.availability).toEqual(
+      campaignStateFactory.availabilityDaysFixture
+        .slice(beginningOfLastWeek)
+        .reduce((acc, avail) => (acc += avail.numbers.availability + avail.numbers.allocated), 0)
+    );
+    expect(rollups[0].totals.availability).toEqual(
+      campaignStateFactory.availabilityDaysFixture
+        .slice(campaignStateFactory.availabilityDaysFixture.findIndex(avail => new Date(avail.date).valueOf() > Date.now()) - 1)
+        .reduce((acc, avail) => (acc += avail.numbers.availability + avail.numbers.allocated), 0)
+    );
+  });
+
+  it('should roll up into weekly inventory and include allocation preview', () => {
     const rollups: AvailabilityRollup[] = comboSelectors.selectAvailabilityRollup.projector(
       campaignStateFactory.availabilityEntities,
       campaignStateFactory.allocationPreviewEntities,
@@ -33,26 +85,77 @@ describe('Availability-Allocation-Actuals Combination Selectors', () => {
     expect(rollups[0].params).toEqual(campaignStateFactory.availabilityParamsFixture);
     expect(rollups[0].weeks[0].startDate).toEqual(campaignStateFactory.availabilityDaysFixture[0].date);
     expect(new Date(rollups[0].weeks[0].endDate).getUTCDay()).toEqual(6);
-    const firstSaturday = campaignStateFactory.availabilityDaysFixture.findIndex(day => day.date.getUTCDay() === 6);
-    expect(rollups[0].weeks[0].numbers.availability).toEqual(
-      campaignStateFactory.availabilityDaysFixture
-        .slice(0, firstSaturday + 1)
-        .reduce((acc, avail) => (acc += avail.numbers.availability), 0)
-    );
+
+    // check the first week for allocated/actuals/allocationPreview
+    const endOfFirstWeek = campaignStateFactory.availabilityDaysFixture.findIndex(day => moment.utc(day.date).day() === 6);
     expect(rollups[0].weeks[0].numbers.allocated).toEqual(
-      campaignStateFactory.availabilityDaysFixture.slice(0, firstSaturday + 1).reduce((acc, avail) => (acc += avail.numbers.allocated), 0)
+      campaignStateFactory.availabilityDaysFixture.slice(0, endOfFirstWeek + 1).reduce((acc, avail) => (acc += avail.numbers.allocated), 0)
+    );
+    expect(rollups[0].weeks[0].numbers.actuals).toEqual(
+      campaignStateFactory.availabilityDaysFixture.slice(0, endOfFirstWeek + 1).reduce((acc, avail) => (acc += avail.numbers.actuals), 0)
     );
     expect(rollups[0].weeks[0].numbers.allocationPreview).toEqual(
-      campaignStateFactory.allocationPreviewFixture.slice(0, firstSaturday + 1).reduce((acc, alloc) => (acc += alloc.goalCount), 0)
+      campaignStateFactory.allocationPreviewFixture.slice(0, endOfFirstWeek + 1).reduce((acc, alloc) => (acc += alloc.goalCount), 0)
     );
-    expect(rollups[0].totals.availability).toEqual(
-      campaignStateFactory.availabilityDaysFixture.reduce((acc, avail) => (acc += avail.numbers.availability), 0)
-    );
+
     expect(rollups[0].totals.allocated).toEqual(
       campaignStateFactory.availabilityDaysFixture.reduce((acc, avail) => (acc += avail.numbers.allocated), 0)
     );
+    expect(rollups[0].totals.actuals).toEqual(
+      campaignStateFactory.availabilityDaysFixture.reduce((acc, avail) => (acc += avail.numbers.actuals), 0)
+    );
     expect(rollups[0].totals.allocationPreview).toEqual(
       campaignStateFactory.allocationPreviewFixture.reduce((acc, alloc) => (acc += alloc.goalCount), 0)
+    );
+  });
+
+  it('should initialize weekly data with first daily entry summing the availability and allocated amounts into availability', () => {
+    const availabilityState = campaignStateFactory.createAvailabilityState().availability;
+    const availabilityDay =
+      availabilityState.entities[selectAvailabilityId(availabilityState.entities[Object.keys(availabilityState.entities)[0]])].days[0];
+    expect(
+      comboSelectors.initWeeklyData(true, availabilityDay, comboSelectors.getEndOfWeek(allocationPreviewState.startAt)).numbers.availability
+    ).toEqual(availabilityDay.numbers.allocated + availabilityDay.numbers.availability);
+    expect(
+      comboSelectors.initWeeklyData(false, availabilityDay, comboSelectors.getEndOfWeek(allocationPreviewState.startAt)).numbers
+        .availability
+    ).toEqual(0);
+  });
+
+  it('should accumulate daily numbers onto weekly rollups', () => {
+    const availabilityState = campaignStateFactory.createAvailabilityState().availability;
+    const availabilityDay0 =
+      availabilityState.entities[selectAvailabilityId(availabilityState.entities[Object.keys(availabilityState.entities)[0]])].days[0];
+    const availabilityDay1 =
+      availabilityState.entities[selectAvailabilityId(availabilityState.entities[Object.keys(availabilityState.entities)[0]])].days[1];
+    const weeklyRollup = comboSelectors.initWeeklyData(true, availabilityDay0, comboSelectors.getEndOfWeek(allocationPreviewState.startAt));
+    expect(comboSelectors.accumulateOntoWeekly(true, weeklyRollup, availabilityDay1).numbers.availability).toEqual(
+      availabilityDay0.numbers.allocated +
+        availabilityDay0.numbers.availability +
+        availabilityDay1.numbers.allocated +
+        availabilityDay1.numbers.availability
+    );
+    expect(comboSelectors.accumulateOntoWeekly(false, weeklyRollup, availabilityDay1).numbers.availability).toEqual(0);
+  });
+
+  it('should get midnight UTC value for a given date', () => {
+    expect(new Date(comboSelectors.getMidnightUTC(new Date())).getUTCHours()).toEqual(0);
+    expect(new Date(comboSelectors.getMidnightUTC(new Date())).getUTCMinutes()).toEqual(0);
+    expect(new Date(comboSelectors.getMidnightUTC(new Date())).getUTCSeconds()).toEqual(0);
+    expect(new Date(comboSelectors.getMidnightUTC(new Date())).getUTCMilliseconds()).toEqual(0);
+  });
+
+  it('should get the end of the week for a given date', () => {
+    expect(comboSelectors.getEndOfWeek(new Date()).getUTCDay()).toEqual(6);
+    expect(comboSelectors.getEndOfWeek(new Date()).getUTCHours()).toEqual(23);
+    expect(comboSelectors.getEndOfWeek(new Date()).getUTCMinutes()).toEqual(59);
+    expect(comboSelectors.getEndOfWeek(new Date()).getUTCSeconds()).toEqual(59);
+    expect(comboSelectors.getEndOfWeek(new Date()).getUTCMilliseconds()).toEqual(999);
+  });
+
+  it('should get a UTC date string from a Date', () => {
+    expect(comboSelectors.getDateSlice(new Date())).toEqual(
+      `${new Date().getUTCFullYear()}-${('0' + (new Date().getUTCMonth() + 1)).slice(-2)}-${('0' + new Date().getUTCDate()).slice(-2)}`
     );
   });
 });

--- a/src/app/campaign/store/selectors/availability-allocation-actuals.selectors.ts
+++ b/src/app/campaign/store/selectors/availability-allocation-actuals.selectors.ts
@@ -1,8 +1,140 @@
 import { createSelector } from '@ngrx/store';
-import { Availability, AvailabilityWeeklyRollup, AvailabilityRollup } from '../models';
+import {
+  Availability,
+  AvailabilityWeeklyRollup,
+  AvailabilityRollup,
+  AllocationPreview,
+  AvailabilityParams,
+  InventoryNumbers,
+  AvailabilityDay
+} from '../models';
 import { selectRoutedFlightAvailabilityEntities } from './availability.selectors';
 import { selectRoutedFlightAllocationPreviewEntities } from './allocation-preview.selectors';
 import { selectRoutedFlightId, selectRoutedLocalFlightZones } from './flight.selectors';
+
+export const getAllocationPreviewForDate = (
+  dateString: string,
+  zone: string,
+  allocationPreviewEntities: { [id: string]: AllocationPreview }
+): number => {
+  if (allocationPreviewEntities && allocationPreviewEntities[`${zone}_${dateString}`]) {
+    return allocationPreviewEntities[`${zone}_${dateString}`].goalCount;
+  }
+};
+
+export const getMidnightUTC = (date: Date): number => {
+  return date.valueOf() - (date.valueOf() % (24 * 60 * 60 * 1000));
+};
+
+export const getEndOfWeek = (date: Date): Date => {
+  const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999));
+  end.setUTCDate(end.getUTCDate() + (6 - end.getUTCDay()));
+  return end;
+};
+
+export const getDateSlice = (date: Date): string => {
+  return date.toISOString().slice(0, 10);
+};
+
+export const initWeeklyData = (showAvailability: boolean, day: AvailabilityDay, endOfWeek: Date): AvailabilityWeeklyRollup => {
+  // initialize weekly entry with week boundaries and day 0 values
+  return {
+    startDate: day.date,
+    endDate: endOfWeek,
+    numbers: {
+      ...day.numbers,
+      availability: showAvailability ? day.numbers.availability + day.numbers.allocated : 0
+    },
+    days: [
+      {
+        ...day,
+        numbers: {
+          ...day.numbers,
+          availability: showAvailability ? day.numbers.availability + day.numbers.allocated : 0
+        }
+      }
+    ]
+  };
+};
+
+export const accumulateOntoWeekly = (
+  showAvailability: boolean,
+  weekly: AvailabilityWeeklyRollup,
+  day: AvailabilityDay
+): AvailabilityWeeklyRollup => {
+  const sum = (a: number, b: number) => (b ? b + (a || 0) : a);
+  return {
+    ...weekly,
+    numbers: {
+      // allocated and availability will be null rather than undefined, null + 0 === 0
+      allocated: sum(day.numbers.allocated, weekly.numbers.allocated),
+      availability: showAvailability ? sum(day.numbers.availability + day.numbers.allocated, weekly.numbers.availability) : 0,
+      actuals: sum(day.numbers.actuals, weekly.numbers.actuals),
+      allocationPreview: sum(day.numbers.allocationPreview, weekly.numbers.allocationPreview)
+    },
+    days: weekly.days.concat([
+      {
+        ...day,
+        numbers: {
+          ...day.numbers,
+          availability: showAvailability ? day.numbers.availability + day.numbers.allocated : 0
+        }
+      }
+    ])
+  };
+};
+
+// Each week's data is keyed by a date string of beginning of each week's date. The days are accumulated onto it.
+export const rollupWeeks = (
+  availability: Availability,
+  allocationPreviewEntities: { [id: string]: AllocationPreview }
+): { params: AvailabilityParams; totals: InventoryNumbers; weeks: { [weekDate: string]: AvailabilityWeeklyRollup } } => {
+  let beginOfWeek: string;
+  let endOfWeek: Date;
+  // reduce to acc weeks
+  return availability.days.reduce(
+    (acc, day) => {
+      // get the day's allocationPreview from the allocationPreviewEntities which are keyed by `zone_date`
+      day.numbers.allocationPreview = getAllocationPreviewForDate(
+        getDateSlice(day.date),
+        availability.params.zone,
+        allocationPreviewEntities
+      );
+
+      // will zero out availability if date is in the past
+      const showAvailability = getMidnightUTC(day.date) >= getMidnightUTC(new Date());
+
+      // if day.date has passed into the next week (past prior endOfWeek)
+      if (!endOfWeek || endOfWeek.valueOf() <= day.date.valueOf()) {
+        // initial data and begin and end of week
+        beginOfWeek = getDateSlice(day.date);
+        endOfWeek = getEndOfWeek(day.date);
+        acc.weeks[beginOfWeek] = initWeeklyData(showAvailability, day, endOfWeek);
+      } else {
+        // accumulate values onto week until it passes next week boundary
+        acc.weeks[beginOfWeek] = accumulateOntoWeekly(showAvailability, acc.weeks[beginOfWeek], day);
+      }
+      // accumulate days onto totals
+      acc.totals.allocated += day.numbers.allocated;
+      if (showAvailability) {
+        acc.totals.availability += day.numbers.availability + day.numbers.allocated;
+      }
+      acc.totals.actuals += day.numbers.actuals;
+      acc.totals.allocationPreview += day.numbers.allocationPreview;
+      return acc;
+    },
+    {
+      params: availability.params,
+      weeks: {},
+      totals: {
+        allocated: 0,
+        availability: 0,
+        actuals: 0,
+        allocationPreview: 0
+      }
+    }
+  );
+};
 
 export const selectAvailabilityRollup = createSelector(
   selectRoutedFlightAvailabilityEntities,
@@ -16,72 +148,7 @@ export const selectAvailabilityRollup = createSelector(
 
     // group each zone by weeks
     const zoneWeeks =
-      availabilityZones &&
-      availabilityZones.map((availability: Availability) => {
-        // Each week is keyed by a date string of the week begin date. The days are accumulated onto it.
-        let weekBeginString: string;
-        let weekEnd: Date;
-        // reduce to acc weeks
-        return availability.days.reduce(
-          (acc, day) => {
-            // get the day's allocationPreview from the allocationPreviewEntities which are keyed by `zone_date`
-            const dayDate = day.date.toISOString().slice(0, 10);
-            if (allocationPreviewEntities && allocationPreviewEntities[`${availability.params.zone}_${dayDate}`]) {
-              day.numbers.allocationPreview = allocationPreviewEntities[`${availability.params.zone}_${dayDate}`].goalCount;
-            }
-
-            // if dayDate has passed into the next week (past prior weekEnd)
-            if (!weekEnd || weekEnd.valueOf() <= day.date.valueOf()) {
-              // find the week boundaries
-              weekBeginString = dayDate;
-              weekEnd = new Date(Date.UTC(day.date.getUTCFullYear(), day.date.getUTCMonth(), day.date.getUTCDate(), 23, 59, 59));
-              weekEnd.setUTCDate(weekEnd.getUTCDate() + (6 - weekEnd.getUTCDay()));
-
-              // initialize weekly entry with week boundaries and day 0 values
-              acc.weeks[weekBeginString] = {};
-              acc.weeks[weekBeginString].startDate = day.date;
-              acc.weeks[weekBeginString].endDate = weekEnd;
-              acc.weeks[weekBeginString].numbers = {
-                allocated: day.numbers.allocated,
-                availability: day.numbers.availability,
-                actuals: day.numbers.actuals,
-                allocationPreview: day.numbers.allocationPreview
-              };
-              acc.weeks[weekBeginString].days = [day];
-            } else {
-              // accumulate values onto week until it passes next week boundary
-              const sums = acc.weeks[weekBeginString].numbers;
-              acc.weeks[weekBeginString].numbers = {
-                // allocated and availability will be null rather than undefined, null + 0 === 0
-                allocated: sums.allocated ? sums.allocated + day.numbers.allocated : day.numbers.allocated,
-                availability: sums.availability ? sums.availability + day.numbers.availability : day.numbers.availability,
-                actuals: sums.actuals ? sums.actuals + day.numbers.actuals : day.numbers.actuals,
-                allocationPreview: sums.allocationPreview
-                  ? // allocationPreview can be undefined, undefined + 0 === NaN
-                    sums.allocationPreview + (day.numbers.allocationPreview || 0)
-                  : day.numbers.allocationPreview
-              };
-              acc.weeks[weekBeginString].days = acc.weeks[weekBeginString].days.concat([day]);
-            }
-            // accumulate days onto totals
-            acc.totals.allocated += day.numbers.allocated;
-            acc.totals.availability += day.numbers.availability;
-            acc.totals.actuals += day.numbers.actuals;
-            acc.totals.allocationPreview += day.numbers.allocationPreview;
-            return acc;
-          },
-          {
-            params: availability.params,
-            weeks: {},
-            totals: {
-              allocated: 0,
-              availability: 0,
-              actuals: 0,
-              allocationPreview: 0
-            }
-          }
-        );
-      });
+      availabilityZones && availabilityZones.map((availability: Availability) => rollupWeeks(availability, allocationPreviewEntities));
 
     // map weekly acc keys to array and sort by date
     return (


### PR DESCRIPTION
Some of the changes requested in #137
  - When the inventory day's date has passed, zero out availability and display data as bolded in the color light grey
  - When showing the allocation preview data, the column is marked with an `*` and is no longer colored green
  - A blue border line represents the current date. If a week containing the current date is not expanded, the current date indicator is shown on the weekly row. If the week is expanded, the indicator line is shown on the expanded daily row.

Additionally, I have refactored some of the selector code that creates these rollups based on feedback of the really long function that I moved from the CampaignStateService and plopped down into a selector function during the refactor. No one likes to doing bunch of data manipulation and transformations in JavaScript, but I do hope it is more readable. I also moved summing the available and allocated numbers into the selector and out of the component as well as implemented the zeroing of availability data prior to the current date in the selector.