### PR TITLE
179: format dates in dashboard table/cards as UTC

### DIFF
--- a/src/app/dashboard/campaign-card/campaign-flight-dates.pipe.ts
+++ b/src/app/dashboard/campaign-card/campaign-flight-dates.pipe.ts
@@ -28,7 +28,7 @@ export class CampaignFlightDatesPipe implements PipeTransform {
 
   transform(flights: Flight[]): string {
     const dates = this.flightDates(flights);
-    const dateFormat = 'M/DD';
+    const dateFormat = 'M/D';
     if (dates && dates.startAt && dates.endAt) {
       return `${utc(dates.startAt).format(dateFormat)} - ${utc(dates.endAt).format(dateFormat)}`;
     }

--- a/src/app/dashboard/campaign-card/campaign-flight-dates.pipe.ts
+++ b/src/app/dashboard/campaign-card/campaign-flight-dates.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { utc } from 'moment';
 import { Flight } from '../dashboard.service';
 
 @Pipe({
@@ -27,8 +28,9 @@ export class CampaignFlightDatesPipe implements PipeTransform {
 
   transform(flights: Flight[]): string {
     const dates = this.flightDates(flights);
+    const dateFormat = 'M/DD';
     if (dates && dates.startAt && dates.endAt) {
-      return `${dates.startAt.getMonth() + 1}/${dates.startAt.getDate()} - ${dates.endAt.getMonth() + 1}/${dates.endAt.getDate()}`;
+      return `${utc(dates.startAt).format(dateFormat)} - ${utc(dates.endAt).format(dateFormat)}`;
     }
   }
 }

--- a/src/app/dashboard/flight-table/flight-table.component.html
+++ b/src/app/dashboard/flight-table/flight-table.component.html
@@ -1,6 +1,12 @@
 <div class="table-container mat-elevation-z8">
-  <table mat-table [dataSource]="dataSource" matSort [matSortActive]="routedParams?.sort || 'start_at'"
-    [matSortDirection]="routedParams?.direction || 'desc'" matSortDisableClear>
+  <table
+    mat-table
+    [dataSource]="dataSource"
+    matSort
+    [matSortActive]="routedParams?.sort || 'start_at'"
+    [matSortDirection]="routedParams?.direction || 'desc'"
+    matSortDisableClear
+  >
     <ng-container matColumnDef="name" sticky="true">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
         Flight Name
@@ -51,7 +57,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
         Start
       </th>
-      <td mat-cell *matCellDef="let element">{{ element.startAt | date : 'shortDate' : 'UTC' }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.startAt | date: 'shortDate':'UTC' }}</td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
 
@@ -59,7 +65,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
         End
       </th>
-      <td mat-cell *matCellDef="let element">{{ element.endAt | date : 'shortDate' : 'UTC' }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.endAt | date: 'shortDate':'UTC' }}</td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
 
@@ -126,6 +132,12 @@
     <tr mat-footer-row *matFooterRowDef="displayedColumns"></tr>
   </table>
 
-  <mat-paginator class="paginator" [length]="total" [pageSize]="routedParams?.per || 25"
-    [pageIndex]="routedParams?.page - 1 || 0" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons></mat-paginator>
+  <mat-paginator
+    class="paginator"
+    [length]="total"
+    [pageSize]="routedParams?.per || 25"
+    [pageIndex]="routedParams?.page - 1 || 0"
+    [pageSizeOptions]="pageSizeOptions"
+    showFirstLastButtons
+  ></mat-paginator>
 </div>

--- a/src/app/dashboard/flight-table/flight-table.component.html
+++ b/src/app/dashboard/flight-table/flight-table.component.html
@@ -1,12 +1,6 @@
 <div class="table-container mat-elevation-z8">
-  <table
-    mat-table
-    [dataSource]="dataSource"
-    matSort
-    [matSortActive]="routedParams?.sort || 'start_at'"
-    [matSortDirection]="routedParams?.direction || 'desc'"
-    matSortDisableClear
-  >
+  <table mat-table [dataSource]="dataSource" matSort [matSortActive]="routedParams?.sort || 'start_at'"
+    [matSortDirection]="routedParams?.direction || 'desc'" matSortDisableClear>
     <ng-container matColumnDef="name" sticky="true">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
         Flight Name
@@ -57,7 +51,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
         Start
       </th>
-      <td mat-cell *matCellDef="let element">{{ element.startAt | date: 'shortDate' }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.startAt | date : 'shortDate' : 'UTC' }}</td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
 
@@ -65,7 +59,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
         End
       </th>
-      <td mat-cell *matCellDef="let element">{{ element.endAt | date: 'shortDate' }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.endAt | date : 'shortDate' : 'UTC' }}</td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
 
@@ -132,12 +126,6 @@
     <tr mat-footer-row *matFooterRowDef="displayedColumns"></tr>
   </table>
 
-  <mat-paginator
-    class="paginator"
-    [length]="total"
-    [pageSize]="routedParams?.per || 25"
-    [pageIndex]="routedParams?.page - 1 || 0"
-    [pageSizeOptions]="pageSizeOptions"
-    showFirstLastButtons
-  ></mat-paginator>
+  <mat-paginator class="paginator" [length]="total" [pageSize]="routedParams?.per || 25"
+    [pageIndex]="routedParams?.page - 1 || 0" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons></mat-paginator>
 </div>


### PR DESCRIPTION
Closes #179 

### Changes
- Add `'UTC'` timezone param to `data` filter used to display dates in flights table.
- Updates `campaignFlightDates` pipe to format dates with `utc` moment function.