### PR TITLE
orders advertiser, podcast, and geo dashboard filters

### DIFF
--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -16,7 +16,7 @@ import { DashboardService } from './dashboard.service';
 import { DashboardServiceMock } from './dashboard.service.mock';
 
 import { DashboardComponent } from './dashboard.component';
-import { DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent } from './filter';
+import { DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent, LabelOrderPipe } from './filter';
 import { CampaignListSortComponent } from './campaign-list/';
 
 describe('DashboardComponent', () => {
@@ -45,7 +45,8 @@ describe('DashboardComponent', () => {
         FilterFacetComponent,
         FilterTextComponent,
         FilterDateComponent,
-        CampaignListSortComponent
+        CampaignListSortComponent,
+        LabelOrderPipe
       ],
       providers: [
         {

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -27,7 +27,7 @@ import {
 import { DashboardComponent } from './dashboard.component';
 import { dashboardRouting } from './dashboard.routing';
 import { CampaignListComponent, CampaignListSortComponent, CampaignListTotalPagesPipe } from './campaign-list';
-import { DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent } from './filter';
+import { DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent, LabelOrderPipe } from './filter';
 import { FlightTableContainerComponent, FlightTableComponent } from './flight-table/';
 
 @NgModule({
@@ -46,7 +46,8 @@ import { FlightTableContainerComponent, FlightTableComponent } from './flight-ta
     CampaignListSortComponent,
     CampaignListTotalPagesPipe,
     FlightTableContainerComponent,
-    FlightTableComponent
+    FlightTableComponent,
+    LabelOrderPipe
   ],
   imports: [
     dashboardRouting,

--- a/src/app/dashboard/filter/dashboard-filter.component.spec.ts
+++ b/src/app/dashboard/filter/dashboard-filter.component.spec.ts
@@ -8,7 +8,7 @@ import { SharedModule } from '../../shared/shared.module';
 import { DashboardService } from '../dashboard.service';
 import { DashboardServiceMock, facets } from '../dashboard.service.mock';
 
-import { DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent } from '.';
+import { DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent, LabelOrderPipe } from '.';
 
 describe('DashboardFilterComponent', () => {
   let comp: DashboardFilterComponent;
@@ -30,7 +30,7 @@ describe('DashboardFilterComponent', () => {
         MatSelectModule,
         NoopAnimationsModule
       ],
-      declarations: [DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent],
+      declarations: [DashboardFilterComponent, FilterFacetComponent, FilterTextComponent, FilterDateComponent, LabelOrderPipe],
       providers: [
         MatDatepickerModule,
         {

--- a/src/app/dashboard/filter/dashboard-filter.component.ts
+++ b/src/app/dashboard/filter/dashboard-filter.component.ts
@@ -11,7 +11,7 @@ import { DashboardService, DashboardParams, Facets } from '../dashboard.service'
     <div class="selects">
       <grove-filter-facet
         facetName="Podcast"
-        [options]="facets?.podcast"
+        [options]="facets?.podcast | labelOrder: 'label'"
         [selectedOptions]="params?.podcast"
         (selectedOptionsChange)="routeToParams({ podcast: $event })"
       >
@@ -27,14 +27,14 @@ import { DashboardService, DashboardParams, Facets } from '../dashboard.service'
       <grove-filter-facet
         facetName="Geo Target"
         multiple="true"
-        [options]="facets?.geo"
+        [options]="facets?.geo | labelOrder: 'label'"
         [selectedOptions]="params?.geo"
         (selectedOptionsChange)="routeToParams({ geo: $event })"
       >
       </grove-filter-facet>
       <grove-filter-facet
         facetName="Advertiser"
-        [options]="facets?.advertiser"
+        [options]="facets?.advertiser | labelOrder: 'label'"
         [selectedOptions]="params?.advertiser"
         (selectedOptionsChange)="routeToParams({ advertiser: $event })"
       >

--- a/src/app/dashboard/filter/index.ts
+++ b/src/app/dashboard/filter/index.ts
@@ -2,3 +2,4 @@ export * from './dashboard-filter.component';
 export * from './filter-facet.component';
 export * from './filter-text.component';
 export * from './filter-date.component';
+export * from './label-order.pipe';

--- a/src/app/dashboard/filter/label-order.pipe.ts
+++ b/src/app/dashboard/filter/label-order.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'labelOrder'
+})
+export class LabelOrderPipe implements PipeTransform {
+  transform(options: { [label: string]: string }[], label: string) {
+    if (!options) {
+      return [];
+    }
+    return options.sort((a, b) => a[label].localeCompare(b[label]));
+  }
+}


### PR DESCRIPTION
Adds a sorting pipe to order the advertiser, podcast, and geo options alphabetically by their labels