### PR TITLE
Flight preview status

### DIFF
--- a/src/app/campaign/inventory/inventory.component.spec.ts
+++ b/src/app/campaign/inventory/inventory.component.spec.ts
@@ -111,4 +111,24 @@ describe('InventoryComponent', () => {
     };
     expect(comp.cantShowInventory()).toBeTruthy();
   });
+
+  describe('errors', () => {
+    it('has flight status messages', () => {
+      expect(comp.errors).toEqual([]);
+      comp.flight = { ...flightFixture, statusMessage: 'something bad' };
+      expect(comp.errors).toEqual(['something bad']);
+    });
+
+    it('has flight preview errors', () => {
+      expect(comp.errors).toEqual([]);
+      comp.previewError = 'something bad';
+      expect(comp.errors).toEqual(['something bad']);
+    });
+
+    it('decodes flight preview errors', () => {
+      expect(comp.errors).toEqual([]);
+      comp.previewError = { body: { message: 'something bad' } };
+      expect(comp.errors).toEqual(['something bad']);
+    });
+  });
 });

--- a/src/app/campaign/inventory/inventory.component.ts
+++ b/src/app/campaign/inventory/inventory.component.ts
@@ -34,13 +34,16 @@ export class InventoryComponent {
   zoneWeekExpanded = {};
 
   get errors() {
-    return [
-      // allocation preview error
-      // TODO: Updated with discussed "nice_message" when available.
-      this.previewError && this.previewError.body && this.previewError.body.message,
-      // flight status message, should only exist when there was an error
-      this.flight.status_message
-    ].filter(error => !!error);
+    return [this.decodedPreviewError, this.flight.statusMessage].filter(error => !!error);
+  }
+
+  // TODO: Updated with discussed "nice_message" when available.
+  get decodedPreviewError(): string {
+    if (this.previewError && this.previewError.body && this.previewError.body.message) {
+      return this.previewError.body.message;
+    } else {
+      return this.previewError;
+    }
   }
 
   getZoneName(zoneId: string): string {

--- a/src/app/campaign/store/actions/flight-preview-action.creator.ts
+++ b/src/app/campaign/store/actions/flight-preview-action.creator.ts
@@ -17,7 +17,16 @@ export class FlightPreviewCreate implements Action {
 export class FlightPreviewCreateSuccess implements Action {
   readonly type = ActionTypes.CAMPAIGN_FLIGHT_PREVIEW_CREATE_SUCCESS;
 
-  constructor(public payload: { flight: Flight; flightDaysDocs: HalDoc[]; flightDoc?: HalDoc; campaignDoc?: HalDoc }) {}
+  constructor(
+    public payload: {
+      flight: Flight;
+      status: string;
+      statusMessage: string;
+      flightDaysDocs: HalDoc[];
+      flightDoc?: HalDoc;
+      campaignDoc?: HalDoc;
+    }
+  ) {}
 }
 export class FlightPreviewCreateFailure implements Action {
   readonly type = ActionTypes.CAMPAIGN_FLIGHT_PREVIEW_CREATE_FAILURE;

--- a/src/app/campaign/store/effects/flight-preview.effects.spec.ts
+++ b/src/app/campaign/store/effects/flight-preview.effects.spec.ts
@@ -34,7 +34,7 @@ describe('FlightPreviewEffects', () => {
         {
           provide: FlightPreviewService,
           useValue: {
-            createFlightPreview: jest.fn(() => of(flightDaysDocFixture))
+            createFlightPreview: jest.fn(() => of({ status: 'ok', statusMessage: null, days: flightDaysDocFixture }))
           }
         },
         { provide: Actions, useFactory: getActions }
@@ -48,6 +48,8 @@ describe('FlightPreviewEffects', () => {
   it('should create flight preview', () => {
     const success = new flightPreviewActions.FlightPreviewCreateSuccess({
       flight: flightFixture,
+      status: 'ok',
+      statusMessage: null,
       flightDaysDocs: flightDaysDocFixture,
       flightDoc,
       campaignDoc

--- a/src/app/campaign/store/effects/flight-preview.effects.ts
+++ b/src/app/campaign/store/effects/flight-preview.effects.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
-import { HalDoc } from 'ngx-prx-styleguide';
 import { ActionTypes } from '../actions/action.types';
 import { FlightPreviewService } from '../../../core';
 import * as flightPreviewActions from '../actions/flight-preview-action.creator';

--- a/src/app/campaign/store/effects/flight-preview.effects.ts
+++ b/src/app/campaign/store/effects/flight-preview.effects.ts
@@ -16,10 +16,16 @@ export class FlightPreviewEffects {
     mergeMap(payload => {
       const { flight, flightDoc, campaignDoc } = payload;
       return this.flightPreviewService.createFlightPreview(flight, flightDoc, campaignDoc).pipe(
-        map(
-          (flightDaysDocs: HalDoc[]) =>
-            new flightPreviewActions.FlightPreviewCreateSuccess({ flight, flightDaysDocs, flightDoc, campaignDoc })
-        ),
+        map(({ status, statusMessage, days: flightDaysDocs }) => {
+          return new flightPreviewActions.FlightPreviewCreateSuccess({
+            flight,
+            status,
+            statusMessage,
+            flightDaysDocs,
+            flightDoc,
+            campaignDoc
+          });
+        }),
         catchError(error => of(new flightPreviewActions.FlightPreviewCreateFailure({ flight, error })))
       );
     })

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -20,7 +20,7 @@ export interface Flight {
   dailyMinimum?: number;
   uncapped?: boolean;
   status?: string;
-  status_message?: string;
+  statusMessage?: string;
   createdAt?: Date;
 }
 

--- a/src/app/campaign/store/reducers/flight-days.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight-days.reducer.spec.ts
@@ -112,6 +112,8 @@ describe('Flight Days/Preview Reducer', () => {
       result,
       new flightPreviewActions.FlightPreviewCreateSuccess({
         flight: flightDocFixture,
+        status: 'ok',
+        statusMessage: null,
         flightDaysDocs: flightDaysDocFixture,
         flightDoc: new MockHalDoc(flightDocFixture),
         campaignDoc: new MockHalDoc(campaignDocFixture)

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -1,5 +1,6 @@
 import { MockHalDoc } from 'ngx-prx-styleguide';
 import * as campaignActions from '../actions/campaign-action.creator';
+import * as flightPreviewActions from '../actions/flight-preview-action.creator';
 import {
   campaignDocFixture,
   flightFixture,
@@ -256,5 +257,28 @@ describe('Flight Reducer', () => {
     expect(state.entities[timestamp]).toBeDefined();
     expect(state.entities[timestamp].localFlight.id).toEqual(timestamp);
     expect(state.entities[timestamp].localFlight.createdAt).toBeUndefined();
+  });
+
+  it('should update the flight status/message from preview', () => {
+    let result = reducer(
+      initialState,
+      new campaignActions.CampaignLoadSuccess({
+        campaignDoc: new MockHalDoc(campaignDocFixture),
+        flightDocs: [new MockHalDoc(flightDocFixture)],
+        flightDaysDocs: { [flightDocFixture.id]: flightDaysDocFixture }
+      })
+    );
+    result = reducer(
+      result,
+      new flightPreviewActions.FlightPreviewCreateSuccess({
+        flight: flightFixture,
+        status: 'error',
+        statusMessage: 'something bad',
+        flightDaysDocs: []
+      })
+    );
+    expect(result.entities[flightFixture.id].localFlight).toMatchObject(flightFixture);
+    expect(result.entities[flightFixture.id].localFlight.status).toBe('error');
+    expect(result.entities[flightFixture.id].localFlight.statusMessage).toBe('something bad');
   });
 });

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -1,6 +1,7 @@
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import { ActionTypes } from '../actions/action.types';
 import { CampaignActions } from '../actions/campaign-action.creator';
+import { FlightPreviewActions } from '../actions/flight-preview-action.creator';
 import { docToFlight, duplicateFlight, Flight, FlightState, getFlightId } from '../models';
 
 export interface State extends EntityState<FlightState> {
@@ -12,7 +13,7 @@ export const adapter: EntityAdapter<FlightState> = createEntityAdapter<FlightSta
 
 export const initialState: State = adapter.getInitialState({});
 
-export function reducer(state = initialState, action: CampaignActions): State {
+export function reducer(state = initialState, action: CampaignActions | FlightPreviewActions): State {
   switch (action.type) {
     case ActionTypes.CAMPAIGN_NEW: {
       return { ...adapter.removeAll(state), campaignId: undefined };
@@ -145,6 +146,11 @@ export function reducer(state = initialState, action: CampaignActions): State {
         );
       }
       return newState;
+    }
+    case ActionTypes.CAMPAIGN_FLIGHT_PREVIEW_CREATE_SUCCESS: {
+      const { flight, status, statusMessage } = action.payload;
+      const localFlight = state.entities[flight.id].localFlight;
+      return adapter.updateOne({ id: flight.id, changes: { localFlight: { ...localFlight, status, statusMessage } } }, state);
     }
     default: {
       return state;


### PR DESCRIPTION
closes #197.  Should deploy along with PRX/augury.prx.org#238.  Exceeding availability no longer prevents you from saving the flight - but it does return a `statusMessage`.

This patches through any 201 preview's `status` and `statusMessage` back onto the localFlight so you can see how your pending changes will impact the flight.

![image](https://user-images.githubusercontent.com/1410587/82959116-399f8600-9f74-11ea-9325-7fc2ec68fbea.png)

Also, I kept around the old previewError as that catches/displays some server validation errors nicely:

![image](https://user-images.githubusercontent.com/1410587/82958952-e75e6500-9f73-11ea-83ea-f18e07fb97ca.png)
