### PR TITLE
190: Rearrange flight table columns

### DIFF
--- a/src/app/dashboard/flight-table/flight-table.component.ts
+++ b/src/app/dashboard/flight-table/flight-table.component.ts
@@ -19,17 +19,17 @@ export class FlightTableComponent implements AfterViewInit, OnInit, OnDestroy {
   pageSizeOptions = [25, 50, 100];
   displayedColumns: string[] = [
     'name',
-    'actualCount',
-    'total_goal',
+    'campaign_status',
     'status',
-    'advertiser',
+    'campaign_name',
     'start_at',
     'end_at',
+    'actualCount',
+    'total_goal',
+    'advertiser',
+    'podcast',
     'zone',
     'geo',
-    'podcast',
-    'campaign_name',
-    'campaign_status',
     'campaign_type',
     'campaign_representative'
   ];


### PR DESCRIPTION
Closes #190 

Rearranges flight table columns to match the order in #190. Flight name was left as the first fixed column since removing it seemed inadvisable. (Campaign card list is already weird by not showing the campaign name on the card, right?)