### PR TITLE
195: Hide delete button when flight has actuals

### DIFF
--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -7,13 +7,15 @@
     <div class="inline-fields">
       <mat-form-field appearance="outline">
         <mat-label>Start Date</mat-label>
-        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Start Date" formControlName="startAt" />
+        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Start Date"
+          formControlName="startAt" />
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Actual End Date</mat-label>
-        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="End Date" formControlName="endAt" />
+        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="End Date"
+          formControlName="endAt" />
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
       </mat-form-field>
@@ -46,17 +48,15 @@
         </div>
       </div>
       <div class="add-zone" *ngIf="zonesControls?.length < zoneOptions?.length">
-        <a mat-button routerLink="." (click)="addZone.emit()"><mat-icon>add</mat-icon> Add a creative</a>
+        <a mat-button routerLink="." (click)="addZone.emit()">
+          <mat-icon>add</mat-icon> Add a creative
+        </a>
       </div>
     </fieldset>
   </div>
   <div class="flight-controls-container">
-    <button
-      (click)="onFlightDeleteToggle()"
-      mat-fab
-      [color]="softDeleted ? 'primary' : 'warn'"
-      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'"
-    >
+    <button (click)="onFlightDeleteToggle()" mat-fab [color]="softDeleted ? 'primary' : 'warn'"
+      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'" *ngIf="canBeDeleted">
       <mat-icon>{{ softDeleted ? 'restore_from_trash' : 'delete' }}</mat-icon>
     </button>
     <button (click)="onFlightDuplicate()" mat-fab color="primary" aria-label="Copy flight">

--- a/src/app/campaign/flight/flight-form.component.ts
+++ b/src/app/campaign/flight/flight-form.component.ts
@@ -45,4 +45,8 @@ export class FlightFormComponent implements OnInit {
   get zonesControls(): FormArray {
     return this.flightForm.get('zones') as FormArray;
   }
+
+  get canBeDeleted(): boolean {
+    return !this.flight.actualCount;
+  }
 }

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -17,6 +17,7 @@ export interface Flight {
   set_inventory_uri: string;
   zones: FlightZone[];
   totalGoal: number;
+  actualCount?: number;
   dailyMinimum?: number;
   uncapped?: boolean;
   status?: string;


### PR DESCRIPTION
Closes #195 

This is a superficial solution. My assumption is the API should enforce this with an error response when trying to destroy a flight doc that has actuals, just in case someone manages to bypass this full-proof preventative measure.