### PR TITLE
Contract goal/date fields

### DIFF
--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -78,9 +78,12 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
     name: ['', Validators.required],
     startAt: ['', Validators.required],
     endAt: ['', Validators.required],
+    contractStartAt: [''],
+    contractEndAt: [''],
     zones: this.fb.array([]),
     set_inventory_uri: ['', Validators.required],
     totalGoal: [0, [Validators.required, Validators.min(0)]],
+    contractGoal: ['', Validators.min(0)],
     dailyMinimum: [0, Validators.min(0)],
     uncapped: [false]
   });

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -6,14 +6,14 @@
     </mat-form-field>
     <div class="inline-fields">
       <mat-form-field appearance="outline">
-        <mat-label>Start Date</mat-label>
-        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Start Date" formControlName="startAt" />
+        <mat-label>Actual Start Date</mat-label>
+        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Actual Start Date" formControlName="startAt" />
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Actual End Date</mat-label>
-        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="End Date" formControlName="endAt" />
+        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="Actual End Date" formControlName="endAt" />
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
       </mat-form-field>

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -7,17 +7,41 @@
     <div class="inline-fields">
       <mat-form-field appearance="outline">
         <mat-label>Start Date</mat-label>
-        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Start Date"
-          formControlName="startAt" />
+        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Start Date" formControlName="startAt" />
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Actual End Date</mat-label>
-        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="End Date"
-          formControlName="endAt" />
+        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="End Date" formControlName="endAt" />
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
+      </mat-form-field>
+    </div>
+    <div class="inline-fields">
+      <mat-form-field appearance="outline">
+        <mat-label>Contract Start Date</mat-label>
+        <input
+          matInput
+          [matDatepicker]="contractStartPicker"
+          [max]="flight?.contractEndAt"
+          placeholder="Contract Start Date"
+          formControlName="contractStartAt"
+        />
+        <mat-datepicker-toggle matSuffix [for]="contractStartPicker"></mat-datepicker-toggle>
+        <mat-datepicker #contractStartPicker></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Contract End Date</mat-label>
+        <input
+          matInput
+          [matDatepicker]="contractEndPicker"
+          [min]="flight?.contractStartAt"
+          placeholder="Contract End Date"
+          formControlName="contractEndAt"
+        />
+        <mat-datepicker-toggle matSuffix [for]="contractEndPicker"></mat-datepicker-toggle>
+        <mat-datepicker #contractEndPicker></mat-datepicker>
       </mat-form-field>
     </div>
     <mat-form-field class="flight-form-field" appearance="outline">
@@ -48,15 +72,18 @@
         </div>
       </div>
       <div class="add-zone" *ngIf="zonesControls?.length < zoneOptions?.length">
-        <a mat-button routerLink="." (click)="addZone.emit()">
-          <mat-icon>add</mat-icon> Add a creative
-        </a>
+        <a mat-button routerLink="." (click)="addZone.emit()"> <mat-icon>add</mat-icon> Add a creative </a>
       </div>
     </fieldset>
   </div>
   <div class="flight-controls-container">
-    <button (click)="onFlightDeleteToggle()" mat-fab [color]="softDeleted ? 'primary' : 'warn'"
-      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'" *ngIf="canBeDeleted">
+    <button
+      (click)="onFlightDeleteToggle()"
+      mat-fab
+      [color]="softDeleted ? 'primary' : 'warn'"
+      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'"
+      *ngIf="canBeDeleted"
+    >
       <mat-icon>{{ softDeleted ? 'restore_from_trash' : 'delete' }}</mat-icon>
     </button>
     <button (click)="onFlightDuplicate()" mat-fab color="primary" aria-label="Copy flight">

--- a/src/app/campaign/flight/flight-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-form.component.spec.ts
@@ -79,6 +79,8 @@ class ParentFormComponent {
     name: ['', Validators.required],
     startAt: ['', Validators.required],
     endAt: ['', Validators.required],
+    contractStartAt: [''],
+    contractEndAt: [''],
     zones: this.fb.array([this.fb.group({ id: ['', Validators.required], url: ['', validateMp3] })]),
     set_inventory_uri: ['', Validators.required]
   });

--- a/src/app/campaign/inventory/goal-form.component.spec.ts
+++ b/src/app/campaign/inventory/goal-form.component.spec.ts
@@ -20,6 +20,7 @@ class ParentFormComponent {
 
   goalForm = this.fb.group({
     totalGoal: [0, [Validators.required, Validators.min(0)]],
+    contractGoal: ['', Validators.min(0)],
     dailyMinimum: [0, Validators.min(0)],
     uncapped: [false]
   });
@@ -48,10 +49,10 @@ describe('GoalFormComponent', () => {
 
   it('show form controls based on capped/uncapped form field value', () => {
     comp.goalForm.get('uncapped').setValue(false);
-    expect(de.query(By.css('input[type="number"]')).nativeElement).toBeDefined();
+    expect(de.query(By.css('input[formcontrolname="totalGoal"]')).nativeElement).toBeDefined();
     comp.goalForm.get('uncapped').setValue(true);
     fix.detectChanges();
-    expect(de.query(By.css('input[type="number"]'))).toBeNull();
+    expect(de.query(By.css('input[formcontrolname="totalGoal"]'))).toBeNull();
     expect(de.query(By.css('.warn')).nativeElement).toBeDefined();
   });
 });

--- a/src/app/campaign/inventory/goal-form.component.ts
+++ b/src/app/campaign/inventory/goal-form.component.ts
@@ -15,6 +15,10 @@ import { ControlContainer, FormGroup } from '@angular/forms';
         <mat-label>Daily Minimum</mat-label>
         <input type="number" matInput placeholder="Daily Minimum" formControlName="dailyMinimum" />
       </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Contract Goal</mat-label>
+        <input type="number" matInput placeholder="Contract Goal" formControlName="contractGoal" />
+      </mat-form-field>
     </div>
     <div *ngIf="!isCapped">
       <p>

--- a/src/app/campaign/inventory/inventory.component.spec.ts
+++ b/src/app/campaign/inventory/inventory.component.spec.ts
@@ -28,6 +28,7 @@ class ParentFormComponent {
 
   goalForm = this.fb.group({
     totalGoal: [0, [Validators.required, Validators.min(0)]],
+    contractGoal: ['', Validators.min(0)],
     dailyMinimum: [0, Validators.min(0)],
     uncapped: [false]
   });

--- a/src/app/campaign/store/actions/campaign-action.service.spec.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.spec.ts
@@ -82,6 +82,56 @@ describe('CampaignActionService', () => {
     });
   });
 
+  describe('flight form update', () => {
+    it('dispatches updates when the form changes', () => {
+      const flight = { ...flightFixture, name: 'new name' };
+      service.updateFlightForm(flight, true, true);
+      expect(dispatchSpy).toHaveBeenCalledWith(new campaignActions.CampaignFlightFormUpdate({ flight, changed: true, valid: true }));
+    });
+
+    it('does not dispatch non-changes', () => {
+      const flight = { ...flightFixture };
+      service.updateFlightForm(flight, true, true);
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasChanged', () => {
+    it('compares arrays', () => {
+      expect(service.hasChanged([], [])).toEqual(false);
+      expect(service.hasChanged(['one'], ['one'])).toEqual(false);
+      expect(service.hasChanged(['one'], ['two'])).toEqual(true);
+      expect(service.hasChanged(['one'], ['one', 'two'])).toEqual(true);
+      expect(service.hasChanged(['one', 'two'], ['one'])).toEqual(true);
+    });
+
+    it('compares objects', () => {
+      expect(service.hasChanged({}, {})).toEqual(false);
+      expect(service.hasChanged({ one: 1 }, { one: 1 })).toEqual(false);
+      expect(service.hasChanged({ one: 1 }, { one: 2 })).toEqual(true);
+      expect(service.hasChanged({ one: 1 }, { two: 2 })).toEqual(true);
+      expect(service.hasChanged({ one: 1 }, { one: 1, two: 2 })).toEqual(false);
+      expect(service.hasChanged({ one: 1, two: 2 }, { one: 1 })).toEqual(true);
+    });
+
+    it('compares other stuff', () => {
+      expect(service.hasChanged('a', 'a')).toEqual(false);
+      expect(service.hasChanged('a', 'b')).toEqual(true);
+      expect(service.hasChanged(1, 1)).toEqual(false);
+      expect(service.hasChanged(1, '1')).toEqual(true);
+      expect(service.hasChanged(null, null)).toEqual(false);
+      expect(service.hasChanged(null, undefined)).toEqual(false);
+      expect(service.hasChanged(undefined, undefined)).toEqual(false);
+      expect(service.hasChanged(undefined, null)).toEqual(false);
+      expect(service.hasChanged(null, false)).toEqual(true);
+    });
+
+    it('compares recursively', () => {
+      expect(service.hasChanged({ a: [{ one: 'one' }] }, { a: [{ one: 'one', two: 'two' }] })).toEqual(false);
+      expect(service.hasChanged({ a: [{ one: 'one' }, { two: 'two' }] }, { a: [{ one: 'one' }, { two: 'three' }] })).toEqual(true);
+    });
+  });
+
   describe('flight preview', () => {
     beforeEach(() => {
       jest.spyOn(service, 'loadFlightPreview');

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -46,15 +46,7 @@ export class CampaignActionService implements OnDestroy {
       }
     }),
     // guard flight form updates
-    filter(([formState, flightState]) => {
-      // are we still dealing with these form updates that aren't actual updates?? maybe just on route change at this point
-      const nameChanged = flightState.localFlight.name !== formState.flight.name;
-      const previewParamsChanged = this.havePreviewParamsChanged(flightState.localFlight, formState.flight);
-      // if (!nameChanged && !previewParamsChanged) {
-      //   console.warn('unchanged?', { formState }, { flightState });
-      // }
-      return nameChanged || previewParamsChanged;
-    })
+    filter(([formState, flightState]) => this.hasChanged(formState.flight, flightState.localFlight))
   );
 
   constructor(private store: Store<any>) {
@@ -75,6 +67,22 @@ export class CampaignActionService implements OnDestroy {
 
   isDateRangeValid({ startAt, endAt }: { startAt: Moment; endAt: Moment }) {
     return startAt && endAt && startAt.valueOf() < endAt.valueOf();
+  }
+
+  hasChanged(a: any, b: any) {
+    if (a instanceof Array && b instanceof Array) {
+      // arrays - compare each item if same length
+      return a.length !== b.length || a.some((val, idx) => this.hasChanged(val, b[idx]));
+    } else if (a instanceof Object && b instanceof Object) {
+      // objects - compare keys in A to B (ignoring keys missing from A)
+      return Object.keys(a).some(key => this.hasChanged(a[key], b[key]));
+    } else if ((a === undefined || a === null) && (b === undefined || b === null)) {
+      // nulls and undefined equate to the same thing
+      return false;
+    } else {
+      // anything else - strict comparison
+      return a !== b;
+    }
   }
 
   hasPreviewParams(flight: Flight): boolean {

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -106,6 +106,7 @@ export const flightFixture: Flight = {
   endAt: moment.utc('2019-11-01'),
   totalGoal: 999,
   dailyMinimum: 99,
+  uncapped: false,
   zones: [{ id: 'pre_1', label: 'Preroll 1' }],
   set_inventory_uri: '/some/inventory'
 };

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -23,6 +23,9 @@ export interface Flight {
   status?: string;
   statusMessage?: string;
   createdAt?: Date;
+  contractGoal?: number;
+  contractStartAt?: Moment;
+  contractEndAt?: Moment;
 }
 
 export interface FlightState {
@@ -40,6 +43,8 @@ export const docToFlight = (doc: HalDoc): Flight => {
   flight.endAt = utc(flight.endAt);
   flight.createdAt = new Date(flight.createdAt);
   flight.set_inventory_uri = doc.expand('prx:inventory');
+  flight.contractStartAt = flight.contractStartAt ? utc(flight.contractStartAt) : null;
+  flight.contractEndAt = flight.contractEndAt ? utc(flight.contractEndAt) : null;
   return flight;
 };
 


### PR DESCRIPTION
Closes #105.

Frontend for PRX/augury.prx.org#251 (and should merge after that).  I'm realizing I didn't exactly follow the design of that ticket - but the header has changed a bit since then?  Hoping that #208 can clean that up.

Adds 3 optional fields to flight form: "Contract Start", "Contract End", and "Contract Goal".

Capped flights: 
![image](https://user-images.githubusercontent.com/1410587/83442281-27ef3000-a405-11ea-9f4d-aa2e46ea18ae.png)

And uncapped flights (note I'm allowing a contract goal here even though you can't have an explicit total_goal ... #208 may clean this up): 
![image](https://user-images.githubusercontent.com/1410587/83442331-39383c80-a405-11ea-8923-ad4306f77256.png)