### PR TITLE
Flight targets

### DIFF
--- a/src/app/campaign/campaign.component.spec.ts
+++ b/src/app/campaign/campaign.component.spec.ts
@@ -39,7 +39,15 @@ describe('CampaignComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule.withRoutes(campaignRoutes),
-        StoreModule.forRoot({ router: routerReducer }),
+        StoreModule.forRoot(
+          { router: routerReducer },
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
         StoreRouterConnectingModule.forRoot({ serializer: CustomRouterSerializer }),
         StoreModule.forFeature('campaignState', reducers),
         SharedModule,

--- a/src/app/campaign/campaign.component.ts
+++ b/src/app/campaign/campaign.component.ts
@@ -18,6 +18,7 @@ import {
 import * as accountActions from './store/actions/account-action.creator';
 import * as advertiserActions from './store/actions/advertiser-action.creator';
 import * as campaignActions from './store/actions/campaign-action.creator';
+import * as inventoryActions from './store/actions/inventory-action.creator';
 import { CampaignActionService } from './store/actions/campaign-action.service';
 
 @Component({
@@ -78,6 +79,7 @@ export class CampaignComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.store.dispatch(accountActions.AccountsLoad());
     this.store.dispatch(advertiserActions.AdvertisersLoad());
+    this.store.dispatch(inventoryActions.InventoryLoad());
     this.routeSub = this.route.paramMap.subscribe(params => {
       if (params.get('id')) {
         const id = +params.get('id');

--- a/src/app/campaign/campaign.module.ts
+++ b/src/app/campaign/campaign.module.ts
@@ -5,6 +5,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
@@ -37,6 +38,7 @@ import { campaignRouting, campaignComponents } from './campaign.routing';
     MatIconModule,
     MatInputModule,
     MatSelectModule,
+    MatCheckboxModule,
     MatSlideToggleModule,
     MatSidenavModule,
     MatListModule,

--- a/src/app/campaign/campaign.module.ts
+++ b/src/app/campaign/campaign.module.ts
@@ -22,6 +22,7 @@ import { AccountEffects } from './store/effects/account.effects';
 import { AdvertiserEffects } from './store/effects/advertiser.effects';
 import { CampaignEffects } from './store/effects/campaign.effects';
 import { FlightPreviewEffects } from './store/effects/flight-preview.effects';
+import { InventoryEffects } from './store/effects/inventory.effects';
 import { CampaignActionService } from './store/actions/campaign-action.service';
 import { campaignRouting, campaignComponents } from './campaign.routing';
 
@@ -47,7 +48,7 @@ import { campaignRouting, campaignComponents } from './campaign.routing';
     FancyFormModule,
     campaignRouting,
     StoreModule.forFeature('campaignState', fromCampaignState.reducers, { metaReducers: fromCampaignState.metaReducers }),
-    EffectsModule.forFeature([AccountEffects, AdvertiserEffects, CampaignEffects, FlightPreviewEffects])
+    EffectsModule.forFeature([AccountEffects, AdvertiserEffects, CampaignEffects, FlightPreviewEffects, InventoryEffects])
   ],
   providers: [CampaignActionService]
 })

--- a/src/app/campaign/campaign.routing.ts
+++ b/src/app/campaign/campaign.routing.ts
@@ -10,6 +10,7 @@ import { CampaignFormComponent } from './form/campaign-form.component';
 import { FlightContainerComponent } from './flight/flight.container';
 import { FlightFormControlContainerComponent } from './flight/flight-form-control-container.component';
 import { FlightFormComponent } from './flight/flight-form.component';
+import { FlightTargetsFormComponent } from './flight/flight-targets-form.component';
 import { InventoryComponent } from './inventory/inventory.component';
 import { InventoryTableComponent } from './inventory/inventory-table.component';
 import { GoalFormComponent } from './inventory/goal-form.component';
@@ -45,6 +46,7 @@ export const campaignComponents: any[] = [
   FlightContainerComponent,
   FlightFormControlContainerComponent,
   FlightFormComponent,
+  FlightTargetsFormComponent,
   InventoryComponent,
   InventoryTableComponent,
   GoalFormComponent

--- a/src/app/campaign/flight/flight-form-control-container.component.spec.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.spec.ts
@@ -8,6 +8,7 @@ import {
   MatInputModule,
   MatSelectModule,
   MatCheckboxModule,
+  MatProgressSpinnerModule,
   MatSlideToggleModule,
   MatDatepickerModule,
   DateAdapter,
@@ -61,6 +62,7 @@ describe('FlightFormControlContainerComponent', () => {
         MatButtonModule,
         MatIconModule,
         MatCheckboxModule,
+        MatProgressSpinnerModule,
         MatSlideToggleModule,
         SharedModule
       ],

--- a/src/app/campaign/flight/flight-form-control-container.component.spec.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.spec.ts
@@ -7,6 +7,7 @@ import {
   MatIconModule,
   MatInputModule,
   MatSelectModule,
+  MatCheckboxModule,
   MatSlideToggleModule,
   MatDatepickerModule,
   DateAdapter,
@@ -24,6 +25,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { SharedModule } from '../../shared/shared.module';
 import { FlightFormControlContainerComponent } from './flight-form-control-container.component';
 import { FlightFormComponent } from './flight-form.component';
+import { FlightTargetsFormComponent } from './flight-targets-form.component';
 import { InventoryComponent } from '../inventory/inventory.component';
 import { InventoryTableComponent } from '../inventory/inventory-table.component';
 import { GoalFormComponent } from '../inventory/goal-form.component';
@@ -58,12 +60,14 @@ describe('FlightFormControlContainerComponent', () => {
         MatMomentDateModule,
         MatButtonModule,
         MatIconModule,
+        MatCheckboxModule,
         MatSlideToggleModule,
         SharedModule
       ],
       declarations: [
         FlightFormControlContainerComponent,
         FlightFormComponent,
+        FlightTargetsFormComponent,
         InventoryComponent,
         InventoryTableComponent,
         GoalFormComponent

--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -29,7 +29,14 @@ export const validateMp3 = (control: AbstractControl): { [key: string]: any } | 
         (addZone)="onAddZone()"
         (removeZone)="onRemoveZone($event)"
       ></grove-flight-form>
-      <grove-inventory [flight]="flight" [zones]="zoneOptions" [rollup]="rollup" [isPreview]="isPreview" [previewError]="previewError">
+      <grove-inventory
+        [flight]="flight"
+        [zones]="zoneOptions"
+        [rollup]="rollup"
+        [isPreview]="isPreview"
+        [isLoading]="isLoading"
+        [previewError]="previewError"
+      >
       </grove-inventory>
     </form>
   `,
@@ -42,6 +49,7 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
   @Input() targetOptions: InventoryTargets;
   @Input() rollup: InventoryRollup;
   @Input() isPreview: boolean;
+  @Input() isLoading: boolean;
   @Input() previewError: any;
   @Output() flightUpdate = new EventEmitter<{ flight: Flight; changed: boolean; valid: boolean }>(true);
   @Output() flightDuplicate = new EventEmitter<Flight>(true);

--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit, OnDestroy, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { FormBuilder, Validators, FormArray, AbstractControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { Inventory, InventoryZone, filterZones } from '../../core';
-import { Flight, InventoryRollup } from '../store/models';
+import { Flight, InventoryRollup, Inventory, InventoryZone, filterZones } from '../store/models';
 
 export const validateMp3 = (control: AbstractControl): { [key: string]: any } | null => {
   if (control.value) {
@@ -18,7 +17,7 @@ export const validateMp3 = (control: AbstractControl): { [key: string]: any } | 
 @Component({
   selector: 'grove-flight',
   template: `
-    <form [formGroup]="flightForm" *ngIf="flightForm && zoneOptions">
+    <form [formGroup]="flightForm">
       <grove-flight-form
         [inventory]="inventory"
         [zoneOptions]="zoneOptions"
@@ -81,6 +80,7 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
     contractStartAt: [''],
     contractEndAt: [''],
     zones: this.fb.array([]),
+    targets: this.fb.array([]),
     set_inventory_uri: ['', Validators.required],
     totalGoal: ['', Validators.min(0)],
     contractGoal: ['', Validators.min(0)],

--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { FormBuilder, Validators, FormArray, AbstractControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { Flight, InventoryRollup, Inventory, InventoryZone, filterZones } from '../store/models';
+import { Flight, InventoryRollup, Inventory, InventoryZone, InventoryTargets, filterZones } from '../store/models';
 
 export const validateMp3 = (control: AbstractControl): { [key: string]: any } | null => {
   if (control.value) {
@@ -21,6 +21,7 @@ export const validateMp3 = (control: AbstractControl): { [key: string]: any } | 
       <grove-flight-form
         [inventory]="inventory"
         [zoneOptions]="zoneOptions"
+        [targetOptions]="targetOptions"
         [flight]="flight"
         [softDeleted]="softDeleted"
         (flightDeleteToggle)="flightDeleteToggle.emit($event)"
@@ -38,6 +39,7 @@ export const validateMp3 = (control: AbstractControl): { [key: string]: any } | 
 export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
   @Input() inventory: Inventory[];
   @Input() zoneOptions: InventoryZone[];
+  @Input() targetOptions: InventoryTargets;
   @Input() rollup: InventoryRollup;
   @Input() isPreview: boolean;
   @Input() previewError: any;
@@ -80,7 +82,7 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
     contractStartAt: [''],
     contractEndAt: [''],
     zones: this.fb.array([]),
-    targets: this.fb.array([]),
+    targets: [''],
     set_inventory_uri: ['', Validators.required],
     totalGoal: ['', Validators.min(0)],
     contractGoal: ['', Validators.min(0)],

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -75,6 +75,7 @@
         <a mat-button routerLink="." (click)="addZone.emit()"> <mat-icon>add</mat-icon> Add a creative </a>
       </div>
     </fieldset>
+    <grove-flight-targets formControlName="targets" [targetOptions]="targetOptions"> </grove-flight-targets>
   </div>
   <div class="flight-controls-container">
     <button

--- a/src/app/campaign/flight/flight-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-form.component.spec.ts
@@ -6,6 +6,7 @@ import {
   MatFormFieldModule,
   MatInputModule,
   MatSelectModule,
+  MatCheckboxModule,
   MatButtonModule,
   MatIconModule,
   MatDatepickerModule,
@@ -22,6 +23,7 @@ import {
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FlightFormComponent } from './flight-form.component';
+import { FlightTargetsFormComponent } from './flight-targets-form.component';
 import { Flight, Inventory } from '../store/models';
 import * as moment from 'moment';
 import { validateMp3 } from './flight-form-control-container.component';
@@ -82,6 +84,7 @@ class ParentFormComponent {
     contractStartAt: [''],
     contractEndAt: [''],
     zones: this.fb.array([this.fb.group({ id: ['', Validators.required], url: ['', validateMp3] })]),
+    targets: [''],
     set_inventory_uri: ['', Validators.required]
   });
 }
@@ -100,12 +103,13 @@ describe('FlightFormComponent', () => {
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
+        MatCheckboxModule,
         MatDatepickerModule,
         MatMomentDateModule,
         MatButtonModule,
         MatIconModule
       ],
-      declarations: [ParentFormComponent, FlightFormComponent],
+      declarations: [ParentFormComponent, FlightFormComponent, FlightTargetsFormComponent],
       providers: [
         { provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS] },
         { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } },

--- a/src/app/campaign/flight/flight-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-form.component.spec.ts
@@ -22,9 +22,8 @@ import {
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FlightFormComponent } from './flight-form.component';
-import { Flight } from '../store/models';
+import { Flight, Inventory } from '../store/models';
 import * as moment from 'moment';
-import { Inventory } from '../../core/';
 import { validateMp3 } from './flight-form-control-container.component';
 
 const inventoryFixture: Inventory[] = [

--- a/src/app/campaign/flight/flight-form.component.ts
+++ b/src/app/campaign/flight/flight-form.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { FormGroup, FormArray, AbstractControl, ControlContainer } from '@angular/forms';
-import { Inventory, InventoryZone, filterZones } from '../../core';
-import { Flight } from '../store/models';
+import { Flight, Inventory, InventoryZone, filterZones } from '../store/models';
 
 @Component({
   selector: 'grove-flight-form',
@@ -47,6 +46,6 @@ export class FlightFormComponent implements OnInit {
   }
 
   get canBeDeleted(): boolean {
-    return !this.flight.actualCount;
+    return this.flight && !this.flight.actualCount;
   }
 }

--- a/src/app/campaign/flight/flight-form.component.ts
+++ b/src/app/campaign/flight/flight-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { FormGroup, FormArray, AbstractControl, ControlContainer } from '@angular/forms';
-import { Flight, Inventory, InventoryZone, filterZones } from '../store/models';
+import { Flight, Inventory, InventoryZone, InventoryTargets, filterZones } from '../store/models';
 
 @Component({
   selector: 'grove-flight-form',
@@ -12,6 +12,7 @@ export class FlightFormComponent implements OnInit {
   @Input() flight: Flight;
   @Input() inventory: Inventory[];
   @Input() zoneOptions: InventoryZone[];
+  @Input() targetOptions: InventoryTargets;
   @Input() softDeleted: boolean;
   @Output() flightDuplicate = new EventEmitter<Flight>(true);
   @Output() flightDeleteToggle = new EventEmitter(true);

--- a/src/app/campaign/flight/flight-targets-form.component.scss
+++ b/src/app/campaign/flight/flight-targets-form.component.scss
@@ -1,0 +1,38 @@
+@import '~src/sass/colors';
+
+:host {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+h2 {
+  margin-bottom: 0.5em;
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.inline-fields {
+  display: grid;
+  grid-column-gap: 0.5rem;
+  grid-template-columns: 1fr 5fr 1fr 40px;
+
+  // allow < 180px width selects
+  ::ng-deep .mat-form-field-infix {
+    width: auto;
+    min-width: 80px;
+  }
+}
+
+.target-exclude,
+.remove-target {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  button {
+    color: mat-color($prx-gray, 300);
+    &:hover {
+      background-color: transparent;
+      color: mat-color($prx-gray, 600);
+    }
+  }
+}

--- a/src/app/campaign/flight/flight-targets-form.component.scss
+++ b/src/app/campaign/flight/flight-targets-form.component.scss
@@ -29,6 +29,7 @@ h2 {
   align-items: center;
   justify-content: center;
   button {
+    margin-bottom: 6px;
     color: mat-color($prx-gray, 300);
     &:hover {
       background-color: transparent;

--- a/src/app/campaign/flight/flight-targets-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.spec.ts
@@ -1,0 +1,132 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ViewChild } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { MatFormFieldModule, MatSelectModule, MatCheckboxModule, MatButtonModule, MatIconModule } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FlightTargetsFormComponent } from './flight-targets-form.component';
+import { InventoryTargets } from '../store/models';
+
+@Component({
+  template: `
+    <form [formGroup]="flightForm">
+      <grove-flight-targets #childForm formControlName="targets" [targetOptions]="options"> </grove-flight-targets>
+    </form>
+  `
+})
+class ParentFormComponent {
+  @ViewChild('childForm', { static: true }) childForm: FlightTargetsFormComponent;
+  constructor(private fb: FormBuilder) {}
+  flightForm = this.fb.group({ targets: [''] });
+  options: InventoryTargets = {
+    inventoryId: 1234,
+    countries: [
+      { type: 'country', code: 'US', label: 'The Us' },
+      { type: 'country', code: 'CA', label: 'The Canadia' }
+    ],
+    episodes: [{ type: 'episode', code: 'AAAA', label: 'The Episoded' }]
+  };
+}
+
+describe('FlightFormComponent', () => {
+  let parent: ParentFormComponent;
+  let component: FlightTargetsFormComponent;
+  let fixture: ComponentFixture<ParentFormComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+        MatFormFieldModule,
+        MatSelectModule,
+        MatCheckboxModule,
+        MatButtonModule,
+        MatIconModule
+      ],
+      declarations: [ParentFormComponent, FlightTargetsFormComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ParentFormComponent);
+    parent = fixture.componentInstance;
+    component = parent.childForm;
+    fixture.detectChanges();
+  });
+
+  it('sets targets from the parent form', () => {
+    expect(component.targets.length).toEqual(0);
+    parent.flightForm.setValue({ targets: [{}] });
+    expect(component.targets.length).toEqual(1);
+    parent.flightForm.reset({ targets: [{}, {}] });
+    expect(component.targets.length).toEqual(2);
+  });
+
+  it('adds targets but only emits them when they have values', () => {
+    expect(parent.flightForm.value).toEqual({ targets: '' });
+    expect(parent.flightForm.dirty).toEqual(false);
+
+    component.addTarget();
+    component.addTarget();
+    expect(parent.flightForm.value).toEqual({ targets: [] });
+    expect(component.targets.length).toEqual(2);
+    expect(parent.flightForm.dirty).toEqual(true);
+
+    component.targets.at(1).setValue({ type: 'country', code: '', exclude: false });
+    expect(parent.flightForm.value).toEqual({ targets: [] });
+
+    component.targets.at(1).setValue({ type: 'country', code: 'CA', exclude: false });
+    expect(parent.flightForm.value).toEqual({ targets: [{ type: 'country', code: 'CA', exclude: false }] });
+  });
+
+  it('removes targets', () => {
+    parent.flightForm.reset({
+      targets: [
+        { type: 'country', code: 'US', exclude: false },
+        { type: 'episode', code: 'AAAA', exclude: false }
+      ]
+    });
+    expect(parent.flightForm.dirty).toEqual(false);
+
+    component.removeTarget(0);
+    expect(parent.flightForm.value).toEqual({ targets: [{ type: 'episode', code: 'AAAA', exclude: false }] });
+    expect(parent.flightForm.dirty).toEqual(true);
+  });
+
+  it('validates targets', () => {
+    expect(parent.flightForm.valid).toEqual(true);
+
+    component.addTarget();
+    expect(parent.flightForm.valid).toEqual(false);
+
+    component.targets.at(0).setValue({ type: 'country', code: '', exclude: false });
+    expect(parent.flightForm.valid).toEqual(false);
+
+    component.targets.at(0).setValue({ type: 'country', code: 'US', exclude: false });
+    expect(parent.flightForm.valid).toEqual(true);
+  });
+
+  it('removes target codes when their type changes', () => {
+    parent.flightForm.reset({ targets: [{ type: 'country', code: 'US', exclude: false }] });
+    expect(component.codeOptions[0]).toEqual(parent.options.countries);
+
+    component.targets.at(0).setValue({ type: 'episode', code: 'US', exclude: false });
+    expect(parent.flightForm.value).toEqual({ targets: [] });
+    expect(component.targets.value).toEqual([{ type: 'episode', code: '', exclude: false }]);
+  });
+
+  it('restricts target codes based on their type', () => {
+    component.addTarget();
+    expect(component.codeOptions[0]).toEqual([]);
+
+    component.targets.at(0).setValue({ type: 'foobar', code: '', exclude: false });
+    expect(component.codeOptions[0]).toEqual([]);
+
+    component.targets.at(0).setValue({ type: 'country', code: '', exclude: false });
+    expect(component.codeOptions[0]).toEqual(parent.options.countries);
+
+    component.targets.at(0).setValue({ type: 'episode', code: '', exclude: false });
+    expect(component.codeOptions[0]).toEqual(parent.options.episodes);
+  });
+});

--- a/src/app/campaign/flight/flight-targets-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.spec.ts
@@ -28,7 +28,7 @@ class ParentFormComponent {
   };
 }
 
-describe('FlightFormComponent', () => {
+describe('FlightTargetsFormComponent', () => {
   let parent: ParentFormComponent;
   let component: FlightTargetsFormComponent;
   let fixture: ComponentFixture<ParentFormComponent>;
@@ -128,5 +128,20 @@ describe('FlightFormComponent', () => {
 
     component.targets.at(0).setValue({ type: 'episode', code: '', exclude: false });
     expect(component.codeOptions[0]).toEqual(parent.options.episodes);
+  });
+
+  it('sorts episode options by publish date', () => {
+    component.targetOptions = {
+      inventoryId: 1234,
+      countries: [],
+      episodes: [
+        { type: 'episode', code: 'A', label: 'Ep A', metadata: { publishedAt: '2020-02-12T00:00:00.000Z' } },
+        { type: 'episode', code: 'B', label: 'Ep B', metadata: { releasedAt: '2020-01-22T00:00:00.000Z' } },
+        { type: 'episode', code: 'C', label: 'Ep C', metadata: { publishedAt: '2020-02-02T00:00:00.000Z' } },
+        { type: 'episode', code: 'D', label: 'Ep D', metadata: { publishedAt: '2020-02-22T00:00:00.000Z' } }
+      ]
+    };
+    parent.flightForm.reset({ targets: [{ type: 'episode', code: '', exclude: false }] });
+    expect(component.codeOptions[0].map(o => o.code)).toEqual(['D', 'A', 'C', 'B']);
   });
 });

--- a/src/app/campaign/flight/flight-targets-form.component.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.ts
@@ -42,6 +42,7 @@ import moment from 'moment';
   ]
 })
 export class FlightTargetsFormComponent implements ControlValueAccessor {
+  // tslint:disable-next-line
   private _targetOptions: InventoryTargets;
   get targetOptions() {
     return this._targetOptions;
@@ -86,6 +87,7 @@ export class FlightTargetsFormComponent implements ControlValueAccessor {
     this.onTouchedFn = fn;
   }
 
+  // tslint:disable-next-line
   validate(_control: FormControl) {
     return !this.targets || this.targets.valid ? null : { error: 'Invalid targets' };
   }
@@ -125,10 +127,10 @@ export class FlightTargetsFormComponent implements ControlValueAccessor {
 
   private filteredTargetOptions(type: string, code: string, currentTargets: FlightTarget[]) {
     return this.targetCodesForType(type).filter(opt => {
-      if (opt.type == type && opt.code == code) {
+      if (opt.type === type && opt.code === code) {
         return true;
       } else {
-        return !currentTargets.find(t => opt.type == t.type && opt.code == t.code);
+        return !currentTargets.find(t => opt.type === t.type && opt.code === t.code);
       }
     });
   }

--- a/src/app/campaign/flight/flight-targets-form.component.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { FormGroup, FormArray, Validators, NG_VALUE_ACCESSOR, NG_VALIDATORS, ControlValueAccessor, FormControl } from '@angular/forms';
 import { InventoryTargets, InventoryTarget, FlightTarget } from '../store/models';
+import moment from 'moment';
 
 @Component({
   selector: 'grove-flight-targets',
@@ -134,11 +135,31 @@ export class FlightTargetsFormComponent implements ControlValueAccessor {
 
   private targetCodesForType(type: string) {
     if (this.targetOptions && type === 'episode') {
-      return this.targetOptions.episodes.sort((a, b) => a.label.localeCompare(b.label));
+      return this.targetOptions.episodes.sort(this.compareEpisodes).map(this.formatEpisodeLabel);
     } else if (this.targetOptions && type === 'country') {
       return this.targetOptions.countries.sort((a, b) => a.label.localeCompare(b.label));
     } else {
       return [];
+    }
+  }
+
+  private compareEpisodes(a: InventoryTarget, b: InventoryTarget) {
+    const apub = a.metadata ? a.metadata.publishedAt || a.metadata.releasedAt : null;
+    const bpub = b.metadata ? b.metadata.publishedAt || b.metadata.releasedAt : null;
+    if (apub && bpub) {
+      return bpub.localeCompare(apub);
+    } else {
+      return a.label.localeCompare(b.label);
+    }
+  }
+
+  private formatEpisodeLabel(t: InventoryTarget) {
+    const pub = t.metadata ? t.metadata.publishedAt || t.metadata.releasedAt : null;
+    if (pub) {
+      const date = moment(pub).format('l');
+      return { ...t, label: `${date} - ${t.label}` };
+    } else {
+      return t;
     }
   }
 }

--- a/src/app/campaign/flight/flight-targets-form.component.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.ts
@@ -1,0 +1,131 @@
+import { Component, OnInit, ChangeDetectionStrategy, Input, Output, EventEmitter } from '@angular/core';
+import {
+  ControlContainer,
+  FormGroup,
+  FormArray,
+  FormBuilder,
+  Validators,
+  NG_VALUE_ACCESSOR,
+  NG_VALIDATORS,
+  ControlValueAccessor,
+  FormControl
+} from '@angular/forms';
+import { InventoryTargets, InventoryTarget, FlightTarget } from '../store/models';
+
+@Component({
+  selector: 'grove-flight-targets',
+  template: `
+    <fieldset *ngIf="targets">
+      <h2>Targets</h2>
+      <div *ngFor="let target of targets.controls; let i = index" [formGroup]="target" class="inline-fields">
+        <mat-form-field class="target-type" appearance="outline">
+          <mat-label>Type</mat-label>
+          <mat-select formControlName="type" required #type>
+            <mat-option *ngFor="let opt of typeOptions" [value]="opt.id">{{ opt.label }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field class="target-code" appearance="outline">
+          <mat-label>Target</mat-label>
+          <mat-select formControlName="code" required #code>
+            <mat-option *ngFor="let opt of codeOptions[i]" [value]="opt.code">{{ opt.label }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <div class="target-exclude mat-form-field-wrapper">
+          <mat-checkbox>Exclude</mat-checkbox>
+        </div>
+        <div class="remove-target mat-form-field-wrapper">
+          <button mat-icon-button aria-label="Remove target" (click)="removeTarget(i)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </div>
+      </div>
+      <div class="add-target">
+        <a mat-button routerLink="." (click)="addTarget()"><mat-icon>add</mat-icon> Add a target</a>
+      </div>
+    </fieldset>
+  `,
+  styleUrls: ['flight-targets-form.component.scss'],
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: FlightTargetsFormComponent, multi: true },
+    { provide: NG_VALIDATORS, useExisting: FlightTargetsFormComponent, multi: true }
+  ]
+})
+export class FlightTargetsFormComponent implements ControlValueAccessor {
+  private _targetOptions: InventoryTargets;
+  get targetOptions() {
+    return this._targetOptions;
+  }
+  @Input()
+  set targetOptions(targetOptions: InventoryTargets) {
+    this._targetOptions = targetOptions;
+    this.setCodeOptions(this.targets ? (this.targets.value as FlightTarget[]) : []);
+  }
+
+  targets: FormArray;
+  onChangeFn: (value: any) => void;
+  onTouchedFn: (value: any) => void;
+  typeOptions = [
+    { id: 'episode', label: 'Episode' },
+    { id: 'country', label: 'Country' }
+  ];
+  codeOptions: InventoryTarget[][];
+
+  writeValue(targets: FlightTarget[]) {
+    console.log('writeValue', targets);
+    this.setCodeOptions(targets);
+    this.targets = new FormArray(
+      (targets || []).map(t => {
+        return new FormGroup({
+          type: new FormControl(t.type, Validators.required),
+          code: new FormControl(t.code, Validators.required),
+          exclude: new FormControl(t.exclude || false)
+        });
+      })
+    );
+    this.targets.valueChanges.subscribe(formTargets => {
+      console.log('valueCHHANGES', JSON.stringify(formTargets));
+      this.onChangeFn(formTargets);
+      this.setCodeOptions(formTargets);
+    });
+  }
+
+  registerOnChange(fn: (value: any) => void) {
+    this.onChangeFn = fn;
+  }
+
+  registerOnTouched(fn: (value: any) => void) {
+    this.onTouchedFn = fn;
+  }
+
+  validate({ value }: FormControl) {
+    console.log('validate', value);
+    return !this.targets || this.targets.valid ? null : { error: 'Some fields are not fullfilled' };
+  }
+
+  setCodeOptions(targets: FlightTarget[]) {
+    console.log('setCodeOptions', targets);
+    this.codeOptions = targets.map(target => {
+      return this.filteredTargetOptions(target.type, target.code, targets);
+    });
+  }
+
+  filteredTargetOptions(type: string, code: string, currentTargets: FlightTarget[]) {
+    return this.targetCodesForType(type).filter(opt => {
+      if (opt.type == type && opt.code == code) {
+        return true;
+      } else {
+        return !currentTargets.find(t => opt.type == t.type && opt.code == t.code);
+      }
+    });
+  }
+
+  targetCodesForType(type: string) {
+    if (this.targetOptions && type === 'episode') {
+      return this.targetOptions.episodes.sort((a, b) => a.label.localeCompare(b.label));
+    } else if (this.targetOptions && type === 'country') {
+      return this.targetOptions.countries.sort((a, b) => a.label.localeCompare(b.label));
+    } else {
+      return [];
+    }
+  }
+}

--- a/src/app/campaign/flight/flight.container.spec.ts
+++ b/src/app/campaign/flight/flight.container.spec.ts
@@ -12,7 +12,8 @@ import {
   MatInputModule,
   MatListModule,
   MatSelectModule,
-  MatSlideToggleModule
+  MatSlideToggleModule,
+  MatCheckboxModule
 } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router, Routes } from '@angular/router';
@@ -31,6 +32,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
 import { FlightContainerComponent } from './flight.container';
 import { FlightFormControlContainerComponent } from './flight-form-control-container.component';
 import { FlightFormComponent } from './flight-form.component';
+import { FlightTargetsFormComponent } from './flight-targets-form.component';
 import { InventoryComponent } from '../inventory/inventory.component';
 import { InventoryTableComponent } from '../inventory/inventory-table.component';
 import { GoalFormComponent } from '../inventory/goal-form.component';
@@ -91,6 +93,7 @@ describe('FlightContainerComponent', () => {
         MatListModule,
         MatSelectModule,
         MatSlideToggleModule,
+        MatCheckboxModule,
         StoreModule.forRoot(
           { router: routerReducer },
           {
@@ -107,6 +110,7 @@ describe('FlightContainerComponent', () => {
         FlightContainerComponent,
         FlightFormControlContainerComponent,
         FlightFormComponent,
+        FlightTargetsFormComponent,
         InventoryComponent,
         InventoryTableComponent,
         GoalFormComponent,

--- a/src/app/campaign/flight/flight.container.spec.ts
+++ b/src/app/campaign/flight/flight.container.spec.ts
@@ -6,6 +6,7 @@ import {
   MatButtonModule,
   MatCardModule,
   MatDatepickerModule,
+  MatNativeDateModule,
   MatFormFieldModule,
   MatIconModule,
   MatInputModule,
@@ -13,20 +14,18 @@ import {
   MatSelectModule,
   MatSlideToggleModule
 } from '@angular/material';
-import { MatMomentDateModule } from '@angular/material-moment-adapter';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ReplaySubject } from 'rxjs';
 import { ActivatedRoute, Router, Routes } from '@angular/router';
 import { ActivatedRouteStub } from '../../../testing/stub.router';
 import { Store, StoreModule } from '@ngrx/store';
 import { StoreRouterConnectingModule, routerReducer } from '@ngrx/router-store';
 import { CustomRouterSerializer } from '../../store/router-store/custom-router-serializer';
 import { MockHalDoc } from 'ngx-prx-styleguide';
-import { InventoryService } from '../../core';
 import { SharedModule } from '../../shared/shared.module';
-import { flightFixture, flightDocFixture, flightDaysData } from '../store/models/campaign-state.factory';
+import { flightFixture, flightDocFixture, flightDaysData, inventoryDocsFixture } from '../store/models/campaign-state.factory';
 import { reducers } from '../store';
 import * as campaignActions from '../store/actions/campaign-action.creator';
+import * as inventoryActions from '../store/actions/inventory-action.creator';
 import { CampaignActionService } from '../store/actions/campaign-action.service';
 
 import { FlightContainerComponent } from './flight.container';
@@ -56,7 +55,6 @@ const campaignRoutes: Routes = [
 ];
 
 describe('FlightContainerComponent', () => {
-  const inventory$: ReplaySubject<any> = new ReplaySubject(1);
   let campaignActionService: CampaignActionService;
   const route: ActivatedRouteStub = new ActivatedRouteStub();
   let router: Router;
@@ -86,14 +84,22 @@ describe('FlightContainerComponent', () => {
         MatButtonModule,
         MatCardModule,
         MatDatepickerModule,
-        MatMomentDateModule,
+        MatNativeDateModule,
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
         MatListModule,
         MatSelectModule,
         MatSlideToggleModule,
-        StoreModule.forRoot({ router: routerReducer }),
+        StoreModule.forRoot(
+          { router: routerReducer },
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
         StoreRouterConnectingModule.forRoot({ serializer: CustomRouterSerializer }),
         StoreModule.forFeature('campaignState', reducers)
       ],
@@ -110,10 +116,6 @@ describe('FlightContainerComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: route
-        },
-        {
-          provide: InventoryService,
-          useValue: { listInventory: jest.fn(() => inventory$) }
         },
         CampaignActionService
       ]
@@ -136,6 +138,7 @@ describe('FlightContainerComponent', () => {
             flightDaysDocs: { [flightDocFixture.id]: (flightDaysData as any[]) as MockHalDoc[] }
           })
         );
+        store.dispatch(inventoryActions.InventoryLoadSuccess({ docs: inventoryDocsFixture }));
         fix.ngZone.run(() => router.navigateByUrl(`/campaign/1/flight/${flightDocFixture.id}`));
       });
   }));
@@ -158,10 +161,18 @@ describe('FlightContainerComponent', () => {
     expect(campaignActionService.updateFlightForm).toHaveBeenCalledWith(flight, true, false);
   });
 
+  it('generates inventory options', done => {
+    component.inventoryOptions$.subscribe(opts => {
+      expect(opts.length).toEqual(inventoryDocsFixture.length);
+      expect(opts.map(opt => opt.id)).toEqual(inventoryDocsFixture.map(doc => doc.id));
+      done();
+    });
+  });
+
   it('generates zone options from inventory', done => {
-    inventory$.next([{ self_uri: flightFixture.set_inventory_uri, zones: flightFixture.zones }]);
     component.zoneOptions$.subscribe(opts => {
-      expect(opts).toEqual(flightFixture.zones);
+      expect(opts.length).toEqual(inventoryDocsFixture[0]['zones'].length);
+      expect(opts.map(opt => opt.id)).toEqual(inventoryDocsFixture[0]['zones'].map((z: any) => z.id));
       done();
     });
   });

--- a/src/app/campaign/flight/flight.container.spec.ts
+++ b/src/app/campaign/flight/flight.container.spec.ts
@@ -12,6 +12,7 @@ import {
   MatInputModule,
   MatListModule,
   MatSelectModule,
+  MatProgressSpinnerModule,
   MatSlideToggleModule,
   MatCheckboxModule
 } from '@angular/material';
@@ -92,6 +93,7 @@ describe('FlightContainerComponent', () => {
         MatInputModule,
         MatListModule,
         MatSelectModule,
+        MatProgressSpinnerModule,
         MatSlideToggleModule,
         MatCheckboxModule,
         StoreModule.forRoot(

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
-import { Flight, InventoryRollup, Inventory, InventoryZone } from '../store/models';
+import { Flight, InventoryRollup, Inventory, InventoryZone, InventoryTargets } from '../store/models';
 import {
   selectRoutedLocalFlight,
   selectRoutedFlightDeleted,
@@ -11,7 +11,8 @@ import {
   selectFlightDaysRollup,
   selectIsFlightPreview,
   selectAllInventoryOrderByName,
-  selectCurrentInventoryZones
+  selectCurrentInventoryZones,
+  selectCurrentInventoryTargets
 } from '../store/selectors';
 import { CampaignActionService } from '../store/actions/campaign-action.service';
 
@@ -20,6 +21,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
     <grove-flight
       [inventory]="inventoryOptions$ | async"
       [zoneOptions]="zoneOptions$ | async"
+      [targetOptions]="targetOptions$ | async"
       [flight]="flightLocal$ | async"
       [softDeleted]="softDeleted$ | async"
       [rollup]="inventoryRollup$ | async"
@@ -42,6 +44,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
   flightPreviewError$: Observable<any>;
   inventoryOptions$: Observable<Inventory[]>;
   zoneOptions$: Observable<InventoryZone[]>;
+  targetOptions$: Observable<InventoryTargets>;
   flightSub: Subscription;
 
   constructor(private store: Store<any>, private campaignAction: CampaignActionService) {}
@@ -56,6 +59,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
     this.isPreview$ = this.store.pipe(select(selectIsFlightPreview));
     this.inventoryOptions$ = this.store.pipe(select(selectAllInventoryOrderByName));
     this.zoneOptions$ = this.store.pipe(select(selectCurrentInventoryZones));
+    this.targetOptions$ = this.store.pipe(select(selectCurrentInventoryTargets));
   }
 
   ngOnDestroy() {

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -28,7 +28,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
       [isPreview]="isPreview$ | async"
       [previewError]="flightPreviewError$ | async"
       (flightUpdate)="flightUpdateFromForm($event)"
-      (flightDeleteToggle)="flightDeleteToggle($event)"
+      (flightDeleteToggle)="flightDeleteToggle()"
       (flightDuplicate)="flightDuplicate($event)"
     ></grove-flight>
   `,

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -10,6 +10,7 @@ import {
   selectRoutedFlightPreviewError,
   selectFlightDaysRollup,
   selectIsFlightPreview,
+  selectIsFlightPreviewLoading,
   selectAllInventoryOrderByName,
   selectCurrentInventoryZones,
   selectCurrentInventoryTargets
@@ -26,6 +27,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
       [softDeleted]="softDeleted$ | async"
       [rollup]="inventoryRollup$ | async"
       [isPreview]="isPreview$ | async"
+      [isLoading]="isLoading$ | async"
       [previewError]="flightPreviewError$ | async"
       (flightUpdate)="flightUpdateFromForm($event)"
       (flightDeleteToggle)="flightDeleteToggle()"
@@ -40,6 +42,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
   flightChanged$: Observable<boolean>;
   inventoryRollup$: Observable<InventoryRollup>;
   isPreview$: Observable<boolean>;
+  isLoading$: Observable<boolean>;
   currentInventoryUri$: Observable<string>;
   flightPreviewError$: Observable<any>;
   inventoryOptions$: Observable<Inventory[]>;
@@ -57,6 +60,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
     this.flightPreviewError$ = this.store.pipe(select(selectRoutedFlightPreviewError));
     this.inventoryRollup$ = this.store.pipe(select(selectFlightDaysRollup));
     this.isPreview$ = this.store.pipe(select(selectIsFlightPreview));
+    this.isLoading$ = this.store.pipe(select(selectIsFlightPreviewLoading));
     this.inventoryOptions$ = this.store.pipe(select(selectAllInventoryOrderByName));
     this.zoneOptions$ = this.store.pipe(select(selectCurrentInventoryZones));
     this.targetOptions$ = this.store.pipe(select(selectCurrentInventoryTargets));

--- a/src/app/campaign/form/campaign-form.container.spec.ts
+++ b/src/app/campaign/form/campaign-form.container.spec.ts
@@ -29,7 +29,15 @@ describe('CampaignFormContainerComponent', () => {
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
-        StoreModule.forRoot({}),
+        StoreModule.forRoot(
+          {},
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
         StoreModule.forFeature('campaignState', reducers)
       ],
       declarations: [CampaignFormContainerComponent, CampaignFormComponent]

--- a/src/app/campaign/inventory/inventory-table.component.scss
+++ b/src/app/campaign/inventory/inventory-table.component.scss
@@ -5,6 +5,24 @@ $row-divider-height: 1px;
 $row-divider-border: $row-divider-height solid prx-theme-foreground(divider);
 $row-height: $row-line-height + $row-divider-height;
 
+:host {
+  display: block;
+  position: relative;
+}
+
+.loading {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.1);
+  ::ng-deep .mat-spinner circle {
+    stroke: mat-color($prx-gray, 100);
+  }
+}
+
 .row {
   transition: background-color 0.6s cubic-bezier(0.25, 0.8, 0.25, 1);
   display: grid;

--- a/src/app/campaign/inventory/inventory-table.component.spec.ts
+++ b/src/app/campaign/inventory/inventory-table.component.spec.ts
@@ -3,7 +3,7 @@ import { DebugElement } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatDividerModule, MatFormFieldModule, MatIconModule, MatInputModule } from '@angular/material';
+import { MatDividerModule, MatFormFieldModule, MatIconModule, MatInputModule, MatProgressSpinnerModule } from '@angular/material';
 import { SharedModule } from '../../shared/shared.module';
 import { InventoryTableComponent } from './inventory-table.component';
 import { InventoryRollup } from '../store/models';
@@ -65,7 +65,8 @@ describe('InventoryTableComponent', () => {
         MatDividerModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule
+        MatInputModule,
+        MatProgressSpinnerModule
       ],
       declarations: [InventoryTableComponent]
     })

--- a/src/app/campaign/inventory/inventory-table.component.ts
+++ b/src/app/campaign/inventory/inventory-table.component.ts
@@ -5,6 +5,7 @@ import { getMidnightUTC, getDateSlice } from '../store/selectors';
 @Component({
   selector: 'grove-inventory-table',
   template: `
+    <div *ngIf="isLoading" class="loading"><mat-spinner diameter="50"></mat-spinner></div>
     <div class="row head">
       <div class="expand"></div>
       <div class="date">Week</div>
@@ -130,6 +131,7 @@ import { getMidnightUTC, getDateSlice } from '../store/selectors';
 export class InventoryTableComponent {
   @Input() flight: Flight;
   @Input() rollup: InventoryRollup;
+  @Input() isLoading: boolean;
   @Input() isPreview: boolean;
   zoneWeekExpanded = {};
 

--- a/src/app/campaign/inventory/inventory.component.spec.ts
+++ b/src/app/campaign/inventory/inventory.component.spec.ts
@@ -7,7 +7,7 @@ import { SharedModule } from '../../shared/shared.module';
 import { InventoryComponent } from './inventory.component';
 import { InventoryTableComponent } from './inventory-table.component';
 import { GoalFormComponent } from './goal-form.component';
-import { InventoryZone } from '../../core';
+import { InventoryZone } from '../store/models';
 import { flightFixture } from '../store/models/campaign-state.factory';
 
 const mockZones: InventoryZone[] = [{ id: 'pre_1', label: 'Preroll 1' }];

--- a/src/app/campaign/inventory/inventory.component.spec.ts
+++ b/src/app/campaign/inventory/inventory.component.spec.ts
@@ -2,7 +2,14 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement, Component, ViewChild } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatDividerModule, MatFormFieldModule, MatIconModule, MatInputModule, MatSelectModule } from '@angular/material';
+import {
+  MatDividerModule,
+  MatFormFieldModule,
+  MatIconModule,
+  MatInputModule,
+  MatSelectModule,
+  MatProgressSpinnerModule
+} from '@angular/material';
 import { SharedModule } from '../../shared/shared.module';
 import { InventoryComponent } from './inventory.component';
 import { InventoryTableComponent } from './inventory-table.component';
@@ -50,7 +57,8 @@ describe('InventoryComponent', () => {
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
-        MatSelectModule
+        MatSelectModule,
+        MatProgressSpinnerModule
       ],
       declarations: [ParentFormComponent, InventoryComponent, InventoryTableComponent, GoalFormComponent]
     })

--- a/src/app/campaign/inventory/inventory.component.ts
+++ b/src/app/campaign/inventory/inventory.component.ts
@@ -1,6 +1,5 @@
 import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter } from '@angular/core';
-import { InventoryZone } from '../../core';
-import { Flight, InventoryRollup } from '../store/models';
+import { Flight, InventoryRollup, InventoryZone } from '../store/models';
 
 @Component({
   selector: 'grove-inventory',

--- a/src/app/campaign/inventory/inventory.component.ts
+++ b/src/app/campaign/inventory/inventory.component.ts
@@ -16,7 +16,13 @@ import { Flight, InventoryRollup, InventoryZone } from '../store/models';
       <mat-divider></mat-divider>
       <section>
         <h3 class="title">{{ zoneNames }}</h3>
-        <grove-inventory-table *ngIf="rollup" [flight]="flight" [rollup]="rollup" [isPreview]="isPreview"></grove-inventory-table>
+        <grove-inventory-table
+          *ngIf="rollup"
+          [flight]="flight"
+          [rollup]="rollup"
+          [isPreview]="isPreview"
+          [isLoading]="isLoading"
+        ></grove-inventory-table>
       </section>
     </ng-template>
   `,
@@ -28,6 +34,7 @@ export class InventoryComponent {
   @Input() zones: InventoryZone[];
   @Input() rollup: InventoryRollup;
   @Input() isPreview: boolean;
+  @Input() isLoading: boolean;
   @Input() previewError: any;
   @Output() goalChange = new EventEmitter<Flight>();
   zoneWeekExpanded = {};

--- a/src/app/campaign/store/actions/action.types.ts
+++ b/src/app/campaign/store/actions/action.types.ts
@@ -32,5 +32,11 @@ export enum ActionTypes {
   CAMPAIGN_ADVERTISERS_LOAD_FAILURE = '[Campaign] Advertisers Load Failure',
   CAMPAIGN_ADD_ADVERTISER = '[Campaign] Add Advertiser',
   CAMPAIGN_ADD_ADVERTISER_SUCCESS = '[Campaign] Add Advertiser Success',
-  CAMPAIGN_ADD_ADVERTISER_FAILURE = '[Campaign] Add Advertiser Failure'
+  CAMPAIGN_ADD_ADVERTISER_FAILURE = '[Campaign] Add Advertiser Failure',
+  CAMPAIGN_INVENTORY_LOAD = '[Campaign] Inventory Load',
+  CAMPAIGN_INVENTORY_LOAD_SUCCESS = '[Campaign] Inventory Load Success',
+  CAMPAIGN_INVENTORY_LOAD_FAILURE = '[Campaign] Inventory Load Failure',
+  CAMPAIGN_INVENTORY_TARGETS_LOAD = '[Campaign] Inventory Targets Load',
+  CAMPAIGN_INVENTORY_TARGETS_LOAD_SUCCESS = '[Campaign] Inventory Targets Load Success',
+  CAMPAIGN_INVENTORY_TARGETS_LOAD_FAILURE = '[Campaign] Inventory Targets Load Failure'
 }

--- a/src/app/campaign/store/actions/campaign-action.service.spec.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.spec.ts
@@ -133,6 +133,15 @@ describe('CampaignActionService', () => {
       expect(service.hasChanged(['one', 'two'], ['one'])).toEqual(true);
     });
 
+    it('compares mismatched arrays', () => {
+      expect(service.hasChanged([], null)).toEqual(false);
+      expect(service.hasChanged([], undefined)).toEqual(false);
+      expect(service.hasChanged([], '')).toEqual(false);
+      expect(service.hasChanged(null, [])).toEqual(false);
+      expect(service.hasChanged([], false)).toEqual(true);
+      expect(service.hasChanged(['one'], null)).toEqual(true);
+    });
+
     it('compares objects', () => {
       expect(service.hasChanged({}, {})).toEqual(false);
       expect(service.hasChanged({ one: 1 }, { one: 1 })).toEqual(false);

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -54,13 +54,17 @@ export class CampaignActionService implements OnDestroy {
   }
 
   transformFlightForm({ flight, changed, valid }: FlightFormState): FlightFormState {
+    // set goal fields based on delivery mode
     if (flight.deliveryMode === 'uncapped') {
-      return { flight: { ...flight, dailyMinimum: null }, changed, valid };
+      flight = { ...flight, dailyMinimum: null };
     } else if (flight.deliveryMode === 'greedy_uncapped') {
-      return { flight: { ...flight, contractGoal: null, dailyMinimum: null }, changed, valid };
-    } else {
-      return { flight, changed, valid };
+      flight = { ...flight, contractGoal: null, dailyMinimum: null };
     }
+
+    // augury doesn't like null targets
+    flight = { ...flight, targets: flight.targets || [] };
+
+    return { flight, changed, valid };
   }
 
   loadFlightPreview(flight: Flight) {

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -101,7 +101,7 @@ export class CampaignActionService implements OnDestroy {
   }
 
   havePreviewParamsChanged(a: Flight, b: Flight) {
-    const check = ['startAt', 'endAt', 'set_inventory_uri', 'zones', 'totalGoal', 'dailyMinimum', 'deliveryMode'];
+    const check = ['startAt', 'endAt', 'set_inventory_uri', 'zones', 'targets', 'totalGoal', 'dailyMinimum', 'deliveryMode'];
     return check.some(fld => {
       if (this.hasChanged(b[fld], a[fld])) {
         // console.log(`previewing BECAUSE ${fld}:`, a[fld], '->', b[fld]);

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -81,6 +81,12 @@ export class CampaignActionService implements OnDestroy {
     if (a instanceof Array && b instanceof Array) {
       // arrays - compare each item if same length
       return a.length !== b.length || a.some((val, idx) => this.hasChanged(val, b[idx]));
+    } else if (a instanceof Array || b instanceof Array) {
+      // array vs non-array - only equal if "empty"
+      return !(
+        (a === undefined || a === null || a === '' || a.length === 0) &&
+        (b === undefined || b === null || b === '' || b.length === 0)
+      );
     } else if (a instanceof Object && b instanceof Object) {
       // objects - compare keys in A to B (ignoring keys missing from A)
       return Object.keys(a).some(key => this.hasChanged(a[key], b[key]));

--- a/src/app/campaign/store/actions/inventory-action.creator.ts
+++ b/src/app/campaign/store/actions/inventory-action.creator.ts
@@ -1,0 +1,21 @@
+import { createAction, props, union } from '@ngrx/store';
+import { ActionTypes } from './action.types';
+import { HalDoc } from 'ngx-prx-styleguide';
+
+export const InventoryLoad = createAction(ActionTypes.CAMPAIGN_INVENTORY_LOAD);
+export const InventoryLoadSuccess = createAction(ActionTypes.CAMPAIGN_INVENTORY_LOAD_SUCCESS, props<{ docs: HalDoc[] }>());
+export const InventoryLoadFailure = createAction(ActionTypes.CAMPAIGN_INVENTORY_LOAD_FAILURE, props<{ error: any }>());
+
+export const InventoryTargetsLoad = createAction(ActionTypes.CAMPAIGN_INVENTORY_TARGETS_LOAD, props<{ inventoryId: number }>());
+export const InventoryTargetsLoadSuccess = createAction(ActionTypes.CAMPAIGN_INVENTORY_TARGETS_LOAD_SUCCESS, props<{ doc: HalDoc }>());
+export const InventoryTargetsLoadFailure = createAction(ActionTypes.CAMPAIGN_INVENTORY_TARGETS_LOAD_FAILURE, props<{ error: any }>());
+
+const all = union({
+  InventoryLoad,
+  InventoryLoadSuccess,
+  InventoryLoadFailure,
+  InventoryTargetsLoad,
+  InventoryTargetsLoadSuccess,
+  InventoryTargetsLoadFailure
+});
+export type InventoryActions = typeof all;

--- a/src/app/campaign/store/actions/inventory-action.creator.ts
+++ b/src/app/campaign/store/actions/inventory-action.creator.ts
@@ -6,7 +6,7 @@ export const InventoryLoad = createAction(ActionTypes.CAMPAIGN_INVENTORY_LOAD);
 export const InventoryLoadSuccess = createAction(ActionTypes.CAMPAIGN_INVENTORY_LOAD_SUCCESS, props<{ docs: HalDoc[] }>());
 export const InventoryLoadFailure = createAction(ActionTypes.CAMPAIGN_INVENTORY_LOAD_FAILURE, props<{ error: any }>());
 
-export const InventoryTargetsLoad = createAction(ActionTypes.CAMPAIGN_INVENTORY_TARGETS_LOAD, props<{ inventoryId: number }>());
+export const InventoryTargetsLoad = createAction(ActionTypes.CAMPAIGN_INVENTORY_TARGETS_LOAD, props<{ inventory: number | HalDoc }>());
 export const InventoryTargetsLoadSuccess = createAction(ActionTypes.CAMPAIGN_INVENTORY_TARGETS_LOAD_SUCCESS, props<{ doc: HalDoc }>());
 export const InventoryTargetsLoadFailure = createAction(ActionTypes.CAMPAIGN_INVENTORY_TARGETS_LOAD_FAILURE, props<{ error: any }>());
 

--- a/src/app/campaign/store/effects/account.effects.spec.ts
+++ b/src/app/campaign/store/effects/account.effects.spec.ts
@@ -20,7 +20,18 @@ describe('AccountEffects', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [StoreModule.forRoot({}), EffectsModule.forRoot([AccountEffects])],
+      imports: [
+        StoreModule.forRoot(
+          {},
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
+        EffectsModule.forRoot([AccountEffects])
+      ],
       providers: [
         AccountEffects,
         {

--- a/src/app/campaign/store/effects/advertiser.effects.spec.ts
+++ b/src/app/campaign/store/effects/advertiser.effects.spec.ts
@@ -23,7 +23,18 @@ describe('AdvertiserEffects', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [StoreModule.forRoot({}), EffectsModule.forRoot([AdvertiserEffects])],
+      imports: [
+        StoreModule.forRoot(
+          {},
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
+        EffectsModule.forRoot([AdvertiserEffects])
+      ],
       providers: [
         AdvertiserEffects,
         {

--- a/src/app/campaign/store/effects/campaign.effects.spec.ts
+++ b/src/app/campaign/store/effects/campaign.effects.spec.ts
@@ -29,7 +29,15 @@ describe('CampaignEffects', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [
-        StoreModule.forRoot({ ...reducers }),
+        StoreModule.forRoot(
+          { ...reducers },
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
         EffectsModule.forRoot([CampaignEffects]),
         RouterTestingModule.withRoutes(campaignRoutes)
       ],

--- a/src/app/campaign/store/effects/flight-preview.effects.spec.ts
+++ b/src/app/campaign/store/effects/flight-preview.effects.spec.ts
@@ -28,7 +28,18 @@ describe('FlightPreviewEffects', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [StoreModule.forRoot({}), EffectsModule.forRoot([FlightPreviewEffects])],
+      imports: [
+        StoreModule.forRoot(
+          {},
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
+        EffectsModule.forRoot([FlightPreviewEffects])
+      ],
       providers: [
         FlightPreviewEffects,
         {

--- a/src/app/campaign/store/effects/inventory.effects.spec.ts
+++ b/src/app/campaign/store/effects/inventory.effects.spec.ts
@@ -1,0 +1,85 @@
+import { Actions } from '@ngrx/effects';
+import { TestBed, async } from '@angular/core/testing';
+import { cold, hot } from 'jasmine-marbles';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { HalHttpError } from 'ngx-prx-styleguide';
+import { InventoryService } from '../../../core';
+import { getActions, TestActions } from '../../../store/test.actions';
+import * as inventoryActions from '../actions/inventory-action.creator';
+import { InventoryEffects } from './inventory.effects';
+import { inventoryDocsFixture, inventoryTargetsDocFixture } from '../models/campaign-state.factory';
+
+describe('InventoryEffects', () => {
+  let effects: InventoryEffects;
+  let actions$: TestActions;
+  let service: InventoryService;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot(
+          {},
+          {
+            runtimeChecks: {
+              strictStateImmutability: true,
+              strictActionImmutability: true
+            }
+          }
+        ),
+        EffectsModule.forRoot([InventoryEffects])
+      ],
+      providers: [
+        InventoryEffects,
+        {
+          provide: InventoryService,
+          useValue: {
+            loadInventory: jest.fn(() => of(inventoryDocsFixture)),
+            loadInventoryTargets: jest.fn(() => of(inventoryTargetsDocFixture))
+          }
+        },
+        { provide: Actions, useFactory: getActions }
+      ]
+    });
+    effects = TestBed.get(InventoryEffects);
+    actions$ = TestBed.get(Actions);
+    service = TestBed.get(InventoryService);
+  }));
+
+  it('loads inventory', () => {
+    const success = inventoryActions.InventoryLoadSuccess({ docs: inventoryDocsFixture });
+
+    actions$.stream = hot('-a', { a: inventoryActions.InventoryLoad() });
+    const expected = cold('-r', { r: success });
+    expect(effects.loadInventory$).toBeObservable(expected);
+  });
+
+  it('fails to load inventory', () => {
+    const error = new HalHttpError(500, 'error occurred');
+    service.loadInventory = jest.fn(() => cold('#', {}, error));
+
+    const outcome = inventoryActions.InventoryLoadFailure({ error });
+    actions$.stream = hot('-a', { a: inventoryActions.InventoryLoad() });
+    const expected = cold('-(b|)', { b: outcome });
+    expect(effects.loadInventory$).toBeObservable(expected);
+  });
+
+  it('loads inventory targets', () => {
+    const success = inventoryActions.InventoryTargetsLoadSuccess({ doc: inventoryTargetsDocFixture });
+
+    actions$.stream = hot('-a', { a: inventoryActions.InventoryTargetsLoad({ inventoryId: 1 }) });
+    const expected = cold('-r', { r: success });
+    expect(effects.loadInventoryTargets$).toBeObservable(expected);
+  });
+
+  it('fails to load inventory targets', () => {
+    const error = new HalHttpError(500, 'error occurred');
+    service.loadInventoryTargets = jest.fn(() => cold('#', {}, error));
+
+    const outcome = inventoryActions.InventoryTargetsLoadFailure({ error });
+    actions$.stream = hot('-a', { a: inventoryActions.InventoryTargetsLoad({ inventoryId: 1 }) });
+    const expected = cold('-(b|)', { b: outcome });
+    expect(effects.loadInventoryTargets$).toBeObservable(expected);
+  });
+});

--- a/src/app/campaign/store/effects/inventory.effects.spec.ts
+++ b/src/app/campaign/store/effects/inventory.effects.spec.ts
@@ -68,7 +68,7 @@ describe('InventoryEffects', () => {
   it('loads inventory targets', () => {
     const success = inventoryActions.InventoryTargetsLoadSuccess({ doc: inventoryTargetsDocFixture });
 
-    actions$.stream = hot('-a', { a: inventoryActions.InventoryTargetsLoad({ inventoryId: 1 }) });
+    actions$.stream = hot('-a', { a: inventoryActions.InventoryTargetsLoad({ inventory: 1 }) });
     const expected = cold('-r', { r: success });
     expect(effects.loadInventoryTargets$).toBeObservable(expected);
   });
@@ -78,7 +78,7 @@ describe('InventoryEffects', () => {
     service.loadInventoryTargets = jest.fn(() => cold('#', {}, error));
 
     const outcome = inventoryActions.InventoryTargetsLoadFailure({ error });
-    actions$.stream = hot('-a', { a: inventoryActions.InventoryTargetsLoad({ inventoryId: 1 }) });
+    actions$.stream = hot('-a', { a: inventoryActions.InventoryTargetsLoad({ inventory: 1 }) });
     const expected = cold('-(b|)', { b: outcome });
     expect(effects.loadInventoryTargets$).toBeObservable(expected);
   });

--- a/src/app/campaign/store/effects/inventory.effects.ts
+++ b/src/app/campaign/store/effects/inventory.effects.ts
@@ -31,7 +31,7 @@ export class InventoryEffects {
   loadInventoryTargetsOnCampaignLoad$ = createEffect(() =>
     this.actions$.pipe(
       ofType(campaignActions.CampaignLoadSuccess),
-      switchMap(_action => this.store.pipe(select(selectCurrentInventory))),
+      switchMap(_ => this.store.pipe(select(selectCurrentInventory))),
       filter(inv => inv && !inv.targets),
       map(inv => inventoryActions.InventoryTargetsLoad({ inventory: inv._doc }))
     )
@@ -40,7 +40,7 @@ export class InventoryEffects {
   loadInventoryTargetsOnFormChange$ = createEffect(() =>
     this.actions$.pipe(
       ofType(campaignActions.CampaignFlightFormUpdate),
-      switchMap(_action => this.store.pipe(select(selectCurrentInventory))),
+      switchMap(_ => this.store.pipe(select(selectCurrentInventory))),
       filter(inv => inv && !inv.targets),
       map(inv => inventoryActions.InventoryTargetsLoad({ inventory: inv._doc }))
     )

--- a/src/app/campaign/store/effects/inventory.effects.ts
+++ b/src/app/campaign/store/effects/inventory.effects.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { catchError, switchMap, map } from 'rxjs/operators';
+import { InventoryService } from '../../../core';
+import * as inventoryActions from '../actions/inventory-action.creator';
+
+@Injectable()
+export class InventoryEffects {
+  loadInventory$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(inventoryActions.InventoryLoad),
+      switchMap(() => this.inventoryService.loadInventory()),
+      map(docs => inventoryActions.InventoryLoadSuccess({ docs })),
+      catchError(error => of(inventoryActions.InventoryLoadFailure({ error })))
+    )
+  );
+
+  loadInventoryTargets$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(inventoryActions.InventoryTargetsLoad),
+      switchMap(action => this.inventoryService.loadInventoryTargets(action.inventoryId)),
+      map(doc => inventoryActions.InventoryTargetsLoadSuccess({ doc })),
+      catchError(error => of(inventoryActions.InventoryTargetsLoadFailure({ error })))
+    )
+  );
+
+  constructor(private actions$: Actions<inventoryActions.InventoryActions>, private inventoryService: InventoryService) {}
+}

--- a/src/app/campaign/store/effects/inventory.effects.ts
+++ b/src/app/campaign/store/effects/inventory.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, switchMap, map, filter, withLatestFrom } from 'rxjs/operators';
+import { catchError, switchMap, map, filter } from 'rxjs/operators';
 import { InventoryService } from '../../../core';
 import { selectCurrentInventory } from '../selectors';
 import * as inventoryActions from '../actions/inventory-action.creator';
@@ -32,7 +32,7 @@ export class InventoryEffects {
     this.actions$.pipe(
       ofType(campaignActions.CampaignLoadSuccess),
       switchMap(_action => this.store.pipe(select(selectCurrentInventory))),
-      filter(inv => !inv.targets),
+      filter(inv => inv && !inv.targets),
       map(inv => inventoryActions.InventoryTargetsLoad({ inventory: inv._doc }))
     )
   );
@@ -41,7 +41,7 @@ export class InventoryEffects {
     this.actions$.pipe(
       ofType(campaignActions.CampaignFlightFormUpdate),
       switchMap(_action => this.store.pipe(select(selectCurrentInventory))),
-      filter(inv => !inv.targets),
+      filter(inv => inv && !inv.targets),
       map(inv => inventoryActions.InventoryTargetsLoad({ inventory: inv._doc }))
     )
   );

--- a/src/app/campaign/store/effects/inventory.effects.ts
+++ b/src/app/campaign/store/effects/inventory.effects.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
+import { Store, select } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, switchMap, map } from 'rxjs/operators';
+import { catchError, switchMap, map, filter, withLatestFrom } from 'rxjs/operators';
 import { InventoryService } from '../../../core';
+import { selectCurrentInventory } from '../selectors';
 import * as inventoryActions from '../actions/inventory-action.creator';
+import * as campaignActions from '../actions/campaign-action.creator';
 
 @Injectable()
 export class InventoryEffects {
@@ -19,11 +22,33 @@ export class InventoryEffects {
   loadInventoryTargets$ = createEffect(() =>
     this.actions$.pipe(
       ofType(inventoryActions.InventoryTargetsLoad),
-      switchMap(action => this.inventoryService.loadInventoryTargets(action.inventoryId)),
+      switchMap(action => this.inventoryService.loadInventoryTargets(action.inventory)),
       map(doc => inventoryActions.InventoryTargetsLoadSuccess({ doc })),
       catchError(error => of(inventoryActions.InventoryTargetsLoadFailure({ error })))
     )
   );
 
-  constructor(private actions$: Actions<inventoryActions.InventoryActions>, private inventoryService: InventoryService) {}
+  loadInventoryTargetsOnCampaignLoad$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(campaignActions.CampaignLoadSuccess),
+      switchMap(_action => this.store.pipe(select(selectCurrentInventory))),
+      filter(inv => !inv.targets),
+      map(inv => inventoryActions.InventoryTargetsLoad({ inventory: inv._doc }))
+    )
+  );
+
+  loadInventoryTargetsOnFormChange$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(campaignActions.CampaignFlightFormUpdate),
+      switchMap(_action => this.store.pipe(select(selectCurrentInventory))),
+      filter(inv => !inv.targets),
+      map(inv => inventoryActions.InventoryTargetsLoad({ inventory: inv._doc }))
+    )
+  );
+
+  constructor(
+    private actions$: Actions<inventoryActions.InventoryActions | campaignActions.CampaignActions>,
+    private inventoryService: InventoryService,
+    private store: Store<any>
+  ) {}
 }

--- a/src/app/campaign/store/index.ts
+++ b/src/app/campaign/store/index.ts
@@ -6,6 +6,7 @@ import * as fromAdvertiser from './reducers/advertiser.reducer';
 import * as fromCampaign from './reducers/campaign.reducer';
 import * as fromFlight from './reducers/flight.reducer';
 import * as fromFlightDays from './reducers/flight-days.reducer';
+import * as fromInventory from './reducers/inventory.reducer';
 
 export interface CampaignStoreState {
   account: fromAccount.State;
@@ -13,6 +14,7 @@ export interface CampaignStoreState {
   campaign: CampaignState;
   flights: fromFlight.State;
   flightDays: fromFlightDays.State;
+  inventory: fromInventory.State;
 }
 
 export const reducers: ActionReducerMap<CampaignStoreState> = {
@@ -20,7 +22,8 @@ export const reducers: ActionReducerMap<CampaignStoreState> = {
   advertiser: fromAdvertiser.reducer,
   campaign: fromCampaign.reducer,
   flights: fromFlight.reducer,
-  flightDays: fromFlightDays.reducer
+  flightDays: fromFlightDays.reducer,
+  inventory: fromInventory.reducer
 };
 
 export const metaReducers: MetaReducer<CampaignStoreState>[] = !environment.production ? [] : [];

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -109,12 +109,12 @@ export const flightFixture: Flight = {
   dailyMinimum: 99,
   deliveryMode: 'capped',
   zones: [{ id: 'pre_1', label: 'Preroll 1' }],
-  set_inventory_uri: '/some/inventory'
+  set_inventory_uri: '/some/inventory/1'
 };
 export const flightDocFixture = {
   ...flightFixture,
   _links: {
-    'prx:inventory': { href: '/some/inventory' }
+    'prx:inventory': { href: '/some/inventory/1' }
   },
   embedded: {
     'prx:flight-days': flightDaysDocFixture
@@ -153,7 +153,7 @@ export const inventoryFixture: Inventory[] = [
   {
     id: 1,
     podcastTitle: 'Some Title 1',
-    self_uri: '/some/uri/1',
+    self_uri: '/some/inventory/1',
     zones: [
       { id: 'pre', label: 'Preroll' },
       { id: 'orig', label: 'Original' }
@@ -162,7 +162,7 @@ export const inventoryFixture: Inventory[] = [
   {
     id: 2,
     podcastTitle: 'Some Title 2',
-    self_uri: '/some/uri/2',
+    self_uri: '/some/inventory/2',
     zones: [
       { id: 'orig', label: 'Original' },
       { id: 'post', label: 'Postroll' }

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -5,6 +5,7 @@ import { Advertiser } from './advertiser.models';
 import { Campaign } from './campaign.models';
 import { Flight } from './flight.models';
 import { docToFlightDays } from './flight-days.models';
+import { Inventory, InventoryTargets } from './inventory.models';
 import * as moment from 'moment';
 
 const augury = new MockHalService();
@@ -148,6 +149,41 @@ export const createFlightDaysState = () => ({
   }
 });
 
+export const inventoryFixture: Inventory[] = [
+  {
+    id: 1,
+    podcastTitle: 'Some Title 1',
+    self_uri: '/some/uri/1',
+    zones: [
+      { id: 'pre', label: 'Preroll' },
+      { id: 'orig', label: 'Original' }
+    ]
+  },
+  {
+    id: 2,
+    podcastTitle: 'Some Title 2',
+    self_uri: '/some/uri/2',
+    zones: [
+      { id: 'orig', label: 'Original' },
+      { id: 'post', label: 'Postroll' }
+    ]
+  }
+];
+export const inventoryDocsFixture = inventoryFixture.map(i => new MockHalDoc({ ...i, _links: { self: { href: i.self_uri } } }));
+export const createInventoryState = () => ({
+  inventory: {
+    ids: inventoryFixture.map(inventory => inventory.id),
+    entities: inventoryFixture.reduce((acc, inventory) => ({ ...acc, [inventory.id]: inventory }), {})
+  }
+});
+
+export const inventoryTargetsFixture: InventoryTargets = {
+  inventoryId: 1,
+  episodes: [{ type: 'episode', code: '1111', label: 'Episode 1' }],
+  countries: [{ type: 'country', code: 'CA', label: 'Canadia' }]
+};
+export const inventoryTargetsDocFixture = new MockHalDoc(inventoryTargetsFixture);
+
 export const createRouterState = () => ({
   router: {
     state: {
@@ -162,11 +198,13 @@ export const createCampaignStoreState = ({
   advertiser = createAdvertiserState(),
   campaignState = createCampaignState(),
   flightsState = createFlightsState(campaignState.campaign.doc),
-  flightDaysState = createFlightDaysState()
+  flightDaysState = createFlightDaysState(),
+  inventoryState = createInventoryState()
 } = {}): CampaignStoreState => ({
   ...account,
   ...advertiser,
   ...campaignState,
   ...flightsState,
-  ...flightDaysState
+  ...flightDaysState,
+  ...inventoryState
 });

--- a/src/app/campaign/store/models/campaign-state.factory.ts
+++ b/src/app/campaign/store/models/campaign-state.factory.ts
@@ -109,6 +109,7 @@ export const flightFixture: Flight = {
   dailyMinimum: 99,
   deliveryMode: 'capped',
   zones: [{ id: 'pre_1', label: 'Preroll 1' }],
+  targets: [],
   set_inventory_uri: '/some/inventory/1'
 };
 export const flightDocFixture = {

--- a/src/app/campaign/store/models/flight-days.models.ts
+++ b/src/app/campaign/store/models/flight-days.models.ts
@@ -18,6 +18,7 @@ export interface FlightDays {
   flightId: number;
   days: FlightDay[];
   preview?: boolean;
+  loading?: boolean;
   previewError?: any;
 }
 export interface InventoryWeeklyRollup {
@@ -52,6 +53,7 @@ export const docToFlightDays = (
       date: utc(doc['date']).toDate()
     })),
     preview,
+    loading: false,
     previewError
   };
 };

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -1,12 +1,20 @@
 import { HalDoc } from 'ngx-prx-styleguide';
 import { filterUnderscores } from './haldoc.utils';
 import { Moment, utc } from 'moment';
+
 export interface FlightZone {
   id: string;
   label?: string;
   url?: string;
   fileSize?: number;
   mimeType?: string;
+}
+
+export interface FlightTarget {
+  type: string;
+  code: string;
+  label?: string;
+  exclude?: boolean;
 }
 
 export interface Flight {
@@ -16,6 +24,7 @@ export interface Flight {
   endAt: Moment;
   set_inventory_uri: string;
   zones: FlightZone[];
+  targets?: FlightTarget[];
   totalGoal?: number;
   actualCount?: number;
   dailyMinimum?: number;
@@ -48,7 +57,7 @@ export const docToFlight = (doc: HalDoc): Flight => {
   return flight;
 };
 
-export const duplicateFlightState = (flight: Flight, tempId: number, changed, valid): FlightState => {
+export const duplicateFlightState = (flight: Flight, tempId: number, changed: boolean, valid: boolean): FlightState => {
   // remove createdAt, startAt, endAt, and set temp id
   const { createdAt, startAt, endAt, name, ...dupFlight } = flight;
 

--- a/src/app/campaign/store/models/index.ts
+++ b/src/app/campaign/store/models/index.ts
@@ -4,3 +4,4 @@ export * from './campaign.models';
 export * from './campaign-flight.models';
 export * from './flight.models';
 export * from './flight-days.models';
+export * from './inventory.models';

--- a/src/app/campaign/store/models/inventory.models.spec.ts
+++ b/src/app/campaign/store/models/inventory.models.spec.ts
@@ -1,0 +1,41 @@
+import { InventoryZone, docToInventory, docToInventoryTargets, filterZones } from './inventory.models';
+import { MockHalDoc } from 'ngx-prx-styleguide';
+
+describe('InventoryModels', () => {
+  it('transforms haldocs to inventory', () => {
+    const doc = new MockHalDoc({ id: 1, podcastTitle: 'title1', what: 'ever', _links: { self: { href: 'href1' } } });
+    expect(docToInventory(doc)).toMatchObject({
+      id: 1,
+      podcastTitle: 'title1',
+      what: 'ever',
+      self_uri: 'href1'
+    });
+  });
+
+  it('transforms a haldoc to an inventory targets', () => {
+    const doc = new MockHalDoc({ inventoryId: 1, episodes: [{ type: 'episode', label: 'episode1', code: 'ep1' }] });
+    expect(docToInventoryTargets(doc)).toMatchObject({
+      inventoryId: 1,
+      episodes: [{ type: 'episode', label: 'episode1', code: 'ep1' }]
+    });
+  });
+
+  it('filters zone options based on the current zone', () => {
+    const zones = [{ id: 'pre_1' }, { id: 'post_1' }] as InventoryZone[];
+    const options = [
+      { id: 'pre_1', label: 'Preroll 1' },
+      { id: 'pre_2', label: 'Preroll 2' },
+      { id: 'post_1', label: 'Postroll 1' },
+      { id: 'post_2', label: 'Postroll 2' }
+    ];
+    expect(filterZones(options, zones).map(z => z.id)).toEqual(['pre_2', 'post_2']);
+    expect(filterZones(options, zones, 0).map(z => z.id)).toEqual(['pre_1', 'pre_2', 'post_2']);
+    expect(filterZones(options, zones, 1).map(z => z.id)).toEqual(['pre_2', 'post_1', 'post_2']);
+  });
+
+  it('defaults zone options to the current zone', () => {
+    const zones = [{ id: 'pre_1', label: 'Preroll 1' }] as InventoryZone[];
+    expect(filterZones(null, zones)).toEqual([]);
+    expect(filterZones(null, zones, 0)).toEqual([{ id: 'pre_1', label: 'Preroll 1' }]);
+  });
+});

--- a/src/app/campaign/store/models/inventory.models.ts
+++ b/src/app/campaign/store/models/inventory.models.ts
@@ -1,0 +1,57 @@
+import { HalDoc } from 'ngx-prx-styleguide';
+import { filterUnderscores } from './haldoc.utils';
+
+export interface Inventory {
+  id: number;
+  podcastTitle: string;
+  zones: InventoryZone[];
+  self_uri: string;
+  episodeTargets?: InventoryTarget[];
+  countryTargets?: InventoryTarget[];
+  _doc?: HalDoc;
+}
+
+export interface InventoryZone {
+  id: string;
+  label: string;
+}
+
+export interface InventoryTarget {
+  type: string;
+  code: string;
+  label: string;
+}
+
+export interface InventoryTargets {
+  inventoryId: number;
+  episodes: InventoryTarget[];
+  countries: InventoryTarget[];
+}
+
+export const docToInventory = (doc: HalDoc): Inventory => {
+  const inventory = filterUnderscores(doc) as Inventory;
+  inventory.self_uri = doc.expand('self');
+  inventory._doc = doc;
+  return inventory;
+};
+
+export const docToInventoryTargets = (doc: HalDoc): InventoryTargets => {
+  return filterUnderscores(doc) as InventoryTargets;
+};
+
+// filter zone options to the control at an index
+export const filterZones = (allZones: InventoryZone[], selectedFlightZones: InventoryZone[], zoneIndex?: number) => {
+  selectedFlightZones = selectedFlightZones || [];
+
+  // if allZones is empty/undefined (hasn't loaded yet,) use the flight.zones as options
+  const options = allZones || selectedFlightZones;
+  return options.filter(zone => {
+    if (selectedFlightZones[zoneIndex] && selectedFlightZones[zoneIndex].id === zone.id) {
+      // include currently selected zone
+      return true;
+    } else {
+      // remove zones selected by other controls
+      return !selectedFlightZones.find(z => z.id === zone.id);
+    }
+  });
+};

--- a/src/app/campaign/store/models/inventory.models.ts
+++ b/src/app/campaign/store/models/inventory.models.ts
@@ -19,6 +19,7 @@ export interface InventoryTarget {
   type: string;
   code: string;
   label: string;
+  metadata?: any;
 }
 
 export interface InventoryTargets {

--- a/src/app/campaign/store/models/inventory.models.ts
+++ b/src/app/campaign/store/models/inventory.models.ts
@@ -6,8 +6,7 @@ export interface Inventory {
   podcastTitle: string;
   zones: InventoryZone[];
   self_uri: string;
-  episodeTargets?: InventoryTarget[];
-  countryTargets?: InventoryTarget[];
+  targets?: InventoryTargets;
   _doc?: HalDoc;
 }
 

--- a/src/app/campaign/store/reducers/flight-days.reducer.ts
+++ b/src/app/campaign/store/reducers/flight-days.reducer.ts
@@ -47,6 +47,9 @@ const _reducer = createReducer(
     }
     return newState;
   }),
+  on(flightPreviewActions.FlightPreviewCreate, (state, action) => {
+    return adapter.updateOne({ id: action.flight.id, changes: { loading: true } }, state);
+  }),
   on(flightPreviewActions.FlightPreviewCreateSuccess, (state, action) => {
     const { flight, flightDoc, flightDaysDocs } = action;
     return adapter.upsertOne(docToFlightDays(flightDoc, flight.id, flightDaysDocs, true), state);

--- a/src/app/campaign/store/reducers/inventory.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/inventory.reducer.spec.ts
@@ -1,6 +1,11 @@
 import * as inventoryActions from '../actions/inventory-action.creator';
 import { reducer, initialState } from './inventory.reducer';
-import { inventoryFixture, inventoryDocsFixture, inventoryTargetsDocFixture } from '../models/campaign-state.factory';
+import {
+  inventoryFixture,
+  inventoryDocsFixture,
+  inventoryTargetsDocFixture,
+  inventoryTargetsFixture
+} from '../models/campaign-state.factory';
 
 describe('Inventory Reducer', () => {
   it('ignores unknown actions', () => {
@@ -25,17 +30,13 @@ describe('Inventory Reducer', () => {
   it('sets inventory targets on load success', () => {
     let state = reducer(initialState, inventoryActions.InventoryLoadSuccess({ docs: inventoryDocsFixture }));
     expect(Object.keys(state.entities)).toEqual(['1', '2']);
-    expect(state.entities['1'].episodeTargets).toBeUndefined();
-    expect(state.entities['1'].countryTargets).toBeUndefined();
-    expect(state.entities['2'].episodeTargets).toBeUndefined();
-    expect(state.entities['2'].countryTargets).toBeUndefined();
+    expect(state.entities['1'].targets).toBeUndefined();
+    expect(state.entities['2'].targets).toBeUndefined();
 
     state = reducer(state, inventoryActions.InventoryTargetsLoadSuccess({ doc: inventoryTargetsDocFixture }));
     expect(inventoryTargetsDocFixture['inventoryId']).toEqual(1);
-    expect(state.entities['1'].episodeTargets).toEqual([{ code: '1111', label: 'Episode 1', type: 'episode' }]);
-    expect(state.entities['1'].countryTargets).toEqual([{ code: 'CA', label: 'Canadia', type: 'country' }]);
-    expect(state.entities['2'].episodeTargets).toBeUndefined();
-    expect(state.entities['2'].countryTargets).toBeUndefined();
+    expect(state.entities['1'].targets).toMatchObject(inventoryTargetsFixture);
+    expect(state.entities['2'].targets).toBeUndefined();
   });
 
   it('sets and clears inventory targets load errors', () => {

--- a/src/app/campaign/store/reducers/inventory.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/inventory.reducer.spec.ts
@@ -1,0 +1,47 @@
+import * as inventoryActions from '../actions/inventory-action.creator';
+import { reducer, initialState } from './inventory.reducer';
+import { inventoryFixture, inventoryDocsFixture, inventoryTargetsDocFixture } from '../models/campaign-state.factory';
+
+describe('Inventory Reducer', () => {
+  it('ignores unknown actions', () => {
+    const result = reducer(initialState, {});
+    expect(result).toBe(initialState);
+  });
+
+  it('sets inventory on load success', () => {
+    const state = reducer(initialState, inventoryActions.InventoryLoadSuccess({ docs: inventoryDocsFixture }));
+    expect(Object.keys(state.entities)).toEqual(['1', '2']);
+    expect(state.entities['1']).toMatchObject(inventoryFixture[0]);
+    expect(state.entities['2']).toMatchObject(inventoryFixture[1]);
+  });
+
+  it('sets and clears inventory load errors', () => {
+    let state = reducer(initialState, inventoryActions.InventoryLoadFailure({ error: 'something bad' }));
+    expect(state.error).toEqual('something bad');
+    state = reducer(state, inventoryActions.InventoryLoadSuccess({ docs: [] }));
+    expect(state.error).toBeNull();
+  });
+
+  it('sets inventory targets on load success', () => {
+    let state = reducer(initialState, inventoryActions.InventoryLoadSuccess({ docs: inventoryDocsFixture }));
+    expect(Object.keys(state.entities)).toEqual(['1', '2']);
+    expect(state.entities['1'].episodeTargets).toBeUndefined();
+    expect(state.entities['1'].countryTargets).toBeUndefined();
+    expect(state.entities['2'].episodeTargets).toBeUndefined();
+    expect(state.entities['2'].countryTargets).toBeUndefined();
+
+    state = reducer(state, inventoryActions.InventoryTargetsLoadSuccess({ doc: inventoryTargetsDocFixture }));
+    expect(inventoryTargetsDocFixture['inventoryId']).toEqual(1);
+    expect(state.entities['1'].episodeTargets).toEqual([{ code: '1111', label: 'Episode 1', type: 'episode' }]);
+    expect(state.entities['1'].countryTargets).toEqual([{ code: 'CA', label: 'Canadia', type: 'country' }]);
+    expect(state.entities['2'].episodeTargets).toBeUndefined();
+    expect(state.entities['2'].countryTargets).toBeUndefined();
+  });
+
+  it('sets and clears inventory targets load errors', () => {
+    let state = reducer(initialState, inventoryActions.InventoryTargetsLoadFailure({ error: 'something bad' }));
+    expect(state.error).toEqual('something bad');
+    state = reducer(state, inventoryActions.InventoryTargetsLoadSuccess({ doc: inventoryTargetsDocFixture }));
+    expect(state.error).toBeNull();
+  });
+});

--- a/src/app/campaign/store/reducers/inventory.reducer.ts
+++ b/src/app/campaign/store/reducers/inventory.reducer.ts
@@ -1,7 +1,7 @@
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 import * as inventoryActions from '../actions/inventory-action.creator';
-import { docToInventory, Inventory } from '../models';
+import { docToInventory, docToInventoryTargets, Inventory } from '../models';
 
 export interface State extends EntityState<Inventory> {
   error?: any;
@@ -20,9 +20,9 @@ const _reducer = createReducer(
   })),
   on(inventoryActions.InventoryLoadFailure, (state, action) => ({ ...state, error: action.error })),
   on(inventoryActions.InventoryTargetsLoadSuccess, (state, action) => {
-    const { inventoryId, episodes, countries } = action.doc as any;
+    const targets = docToInventoryTargets(action.doc);
     return {
-      ...adapter.updateOne({ id: inventoryId, changes: { episodeTargets: episodes, countryTargets: countries } }, state),
+      ...adapter.updateOne({ id: targets.inventoryId, changes: { targets } }, state),
       error: null
     };
   }),

--- a/src/app/campaign/store/reducers/inventory.reducer.ts
+++ b/src/app/campaign/store/reducers/inventory.reducer.ts
@@ -1,0 +1,35 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { createReducer, on } from '@ngrx/store';
+import * as inventoryActions from '../actions/inventory-action.creator';
+import { docToInventory, Inventory } from '../models';
+
+export interface State extends EntityState<Inventory> {
+  error?: any;
+}
+
+export const adapter: EntityAdapter<Inventory> = createEntityAdapter<Inventory>();
+
+export const initialState: State = adapter.getInitialState({});
+
+// tslint:disable-next-line: variable-name
+const _reducer = createReducer(
+  initialState,
+  on(inventoryActions.InventoryLoadSuccess, (state, action) => ({
+    ...adapter.addAll(action.docs.map(docToInventory), state),
+    error: null
+  })),
+  on(inventoryActions.InventoryLoadFailure, (state, action) => ({ ...state, error: action.error })),
+  on(inventoryActions.InventoryTargetsLoadSuccess, (state, action) => {
+    const { inventoryId, episodes, countries } = action.doc as any;
+    return {
+      ...adapter.updateOne({ id: inventoryId, changes: { episodeTargets: episodes, countryTargets: countries } }, state),
+      error: null
+    };
+  }),
+  on(inventoryActions.InventoryTargetsLoadFailure, (state, action) => ({ ...state, error: action.error }))
+);
+export function reducer(state: any, action: any) {
+  return _reducer(state, action);
+}
+
+export const { selectIds, selectEntities, selectAll, selectTotal } = adapter.getSelectors();

--- a/src/app/campaign/store/selectors/flight-days.selectors.ts
+++ b/src/app/campaign/store/selectors/flight-days.selectors.ts
@@ -19,6 +19,7 @@ export const selectRoutedFlightDays = createSelector(
 );
 
 export const selectIsFlightPreview = createSelector(selectRoutedFlightDays, (state): boolean => state && state.preview);
+export const selectIsFlightPreviewLoading = createSelector(selectRoutedFlightDays, (state): boolean => state && state.loading);
 export const selectRoutedFlightPreviewError = createSelector(selectRoutedFlightDays, state => state && state.previewError);
 
 export const getMidnightUTC = (date: Date): number => {

--- a/src/app/campaign/store/selectors/index.ts
+++ b/src/app/campaign/store/selectors/index.ts
@@ -4,3 +4,4 @@ export * from './campaign.selectors';
 export * from './campaign-flight.selectors';
 export * from './flight.selectors';
 export * from './flight-days.selectors';
+export * from './inventory.selectors';

--- a/src/app/campaign/store/selectors/inventory.selectors.ts
+++ b/src/app/campaign/store/selectors/inventory.selectors.ts
@@ -1,0 +1,27 @@
+import { createSelector } from '@ngrx/store';
+import { CampaignStoreState } from '..';
+import { selectCampaignStoreState } from './campaign.selectors';
+import { selectCurrentInventoryUri } from './flight.selectors';
+import { Inventory, InventoryZone } from '../models';
+import { selectIds, selectEntities, selectAll } from '../reducers/inventory.reducer';
+
+export const selectInventoryState = createSelector(selectCampaignStoreState, (state: CampaignStoreState) => state && state.inventory);
+export const selectInventoryIds = createSelector(selectInventoryState, selectIds);
+export const selectInventoryEntities = createSelector(selectInventoryState, selectEntities);
+export const selectAllInventory = createSelector(selectInventoryState, selectAll);
+
+export const selectAllInventoryOrderByName = createSelector(
+  selectAllInventory,
+  inventory => inventory && inventory.sort((a, b) => a.podcastTitle.localeCompare(b.podcastTitle))
+);
+
+export const selectCurrentInventory = createSelector(
+  selectCurrentInventoryUri,
+  selectAllInventory,
+  (uri, allInventory): Inventory => (allInventory || []).find(i => i.self_uri === uri)
+);
+
+export const selectCurrentInventoryZones = createSelector(
+  selectCurrentInventory,
+  (inventory): InventoryZone[] => inventory && inventory.zones
+);

--- a/src/app/campaign/store/selectors/inventory.selectors.ts
+++ b/src/app/campaign/store/selectors/inventory.selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@ngrx/store';
 import { CampaignStoreState } from '..';
 import { selectCampaignStoreState } from './campaign.selectors';
 import { selectCurrentInventoryUri } from './flight.selectors';
-import { Inventory, InventoryZone } from '../models';
+import { Inventory, InventoryZone, InventoryTargets } from '../models';
 import { selectIds, selectEntities, selectAll } from '../reducers/inventory.reducer';
 
 export const selectInventoryState = createSelector(selectCampaignStoreState, (state: CampaignStoreState) => state && state.inventory);
@@ -24,4 +24,9 @@ export const selectCurrentInventory = createSelector(
 export const selectCurrentInventoryZones = createSelector(
   selectCurrentInventory,
   (inventory): InventoryZone[] => inventory && inventory.zones
+);
+
+export const selectCurrentInventoryTargets = createSelector(
+  selectCurrentInventory,
+  (inventory): InventoryTargets => inventory && inventory.targets
 );

--- a/src/app/core/campaign/flight-preview.service.ts
+++ b/src/app/core/campaign/flight-preview.service.ts
@@ -26,7 +26,7 @@ export class FlightPreviewService {
   }
 
   private preview(flight: {}, doc: HalDoc, link: string) {
-    return doc.create(link, {}, flight).pipe(
+    return doc.create(link, {}, this.previewParams(flight)).pipe(
       mergeMap((flightPreviewDoc: HalDoc) => {
         return forkJoin({
           status: of(flightPreviewDoc['status']),
@@ -35,5 +35,13 @@ export class FlightPreviewService {
         });
       })
     );
+  }
+
+  private previewParams(flight: any): any {
+    if (flight.targets && flight.targets.length) {
+      return { ...flight, targets: flight.targets.filter(t => t.type && t.code) };
+    } else {
+      return flight;
+    }
   }
 }

--- a/src/app/core/campaign/flight-preview.service.ts
+++ b/src/app/core/campaign/flight-preview.service.ts
@@ -26,7 +26,7 @@ export class FlightPreviewService {
   }
 
   private preview(flight: {}, doc: HalDoc, link: string) {
-    return doc.create(link, {}, this.previewParams(flight)).pipe(
+    return doc.create(link, {}, flight).pipe(
       mergeMap((flightPreviewDoc: HalDoc) => {
         return forkJoin({
           status: of(flightPreviewDoc['status']),
@@ -35,13 +35,5 @@ export class FlightPreviewService {
         });
       })
     );
-  }
-
-  private previewParams(flight: any): any {
-    if (flight.targets && flight.targets.length) {
-      return { ...flight, targets: flight.targets.filter(t => t.type && t.code) };
-    } else {
-      return flight;
-    }
   }
 }

--- a/src/app/core/inventory/inventory.service.spec.ts
+++ b/src/app/core/inventory/inventory.service.spec.ts
@@ -1,90 +1,41 @@
-import { InventoryService, Inventory, filterZones, InventoryZone } from './inventory.service';
+import { InventoryService } from './inventory.service';
 import { MockHalService } from 'ngx-prx-styleguide';
 import { AuguryService } from '../augury.service';
-import { flightFixture } from '../../campaign/store/models/campaign-state.factory';
 
 describe('InventoryService', () => {
   const augury = new MockHalService();
-  const inventory = new InventoryService(new AuguryService(augury as any));
-  const inventoryFixture: Inventory = {
-    id: 1,
-    podcastTitle: '88% Parentheticals',
-    zones: [{ id: 'pre_1', label: 'Preroll 1' }],
-    self_uri: '/some/inventory'
-  };
-  const availabilityFixture = {
-    startDate: '2019-10-01',
-    endDate: '2019-11-01',
-    days: [
-      { allocated: 0, availability: 1, date: '2019-10-01' },
-      { allocated: 0, availability: 0, date: '2019-10-02' },
-      { allocated: 0, availability: 9858, date: '2019-10-03' },
-      { allocated: 0, availability: 5305, date: '2019-10-04' },
-      { allocated: 0, availability: 2387, date: '2019-10-05' },
-      { allocated: 0, availability: 1339, date: '2019-10-06' },
-      { allocated: 0, availability: 709, date: '2019-10-07' },
-      { allocated: 0, availability: 357, date: '2019-10-08' },
-      { allocated: 0, availability: 158, date: '2019-10-09' },
-      { allocated: 0, availability: 85, date: '2019-10-10' },
-      { allocated: 0, availability: 48, date: '2019-10-11' },
-      { allocated: 0, availability: 19, date: '2019-10-12' },
-      { allocated: 0, availability: 8, date: '2019-10-13' },
-      { allocated: 0, availability: 4, date: '2019-10-14' },
-      { allocated: 0, availability: 1, date: '2019-10-15' },
-      { allocated: 0, availability: 10812, date: '2019-10-16' },
-      { allocated: 0, availability: 5299, date: '2019-10-17' },
-      { allocated: 0, availability: 2527, date: '2019-10-18' },
-      { allocated: 0, availability: 1393, date: '2019-10-20' },
-      { allocated: 0, availability: 722, date: '2019-10-20' },
-      { allocated: 0, availability: 430, date: '2019-10-21' },
-      { allocated: 0, availability: 237, date: '2019-10-22' },
-      { allocated: 0, availability: 97, date: '2019-10-23' },
-      { allocated: 0, availability: 10333, date: '2019-10-24' },
-      { allocated: 0, availability: 6174, date: '2019-10-25' },
-      { allocated: 0, availability: 3567, date: '2019-10-26' },
-      { allocated: 0, availability: 1691, date: '2019-10-27' },
-      { allocated: 0, availability: 765, date: '2019-10-28' },
-      { allocated: 0, availability: 403, date: '2019-10-29' },
-      { allocated: 0, availability: 182, date: '2019-10-30' },
-      { allocated: 0, availability: 91, date: '2019-10-31' }
-    ]
-  };
+  const service = new InventoryService(new AuguryService(augury as any));
 
-  beforeEach(() => {
-    augury.mock('prx:inventory', inventoryFixture).mock('prx:availability', availabilityFixture);
-  });
-
-  it('gets inventory availability', done => {
-    inventory
-      .getInventoryAvailability({
-        id: '1',
-        startDate: '2019-10-01',
-        endDate: '2019-11;01',
-        zone: 'pre_1',
-        flightId: 1
-      })
-      .subscribe(avail => {
-        expect(avail['days'].length).toEqual(availabilityFixture.days.length);
-        expect(avail['startDate']).toEqual(availabilityFixture.startDate);
-        expect(avail['endDate']).toEqual(availabilityFixture.endDate);
-        done();
-      });
-  });
-
-  it('filters zone options based on the current zone', () => {
-    const flightZones = flightFixture.zones.concat([{ id: 'post_1' }]) as InventoryZone[];
-    const zoneOptions = [
-      { id: 'pre_1', label: 'Preroll 1' },
-      { id: 'pre_2', label: 'Preroll 2' },
-      { id: 'post_1', label: 'Postroll 1' },
-      { id: 'post_2', label: 'Postroll 2' }
+  it('lists inventory', done => {
+    const invs = [
+      { id: 1, podcastTitle: 'title 1' },
+      { id: 2, podcastTitle: 'title 2' },
+      { id: 3, podcastTitle: 'title 3' }
     ];
-    expect(filterZones(zoneOptions, flightZones).map(z => z.id)).toEqual(['pre_2', 'post_2']);
-    expect(filterZones(zoneOptions, flightZones, 0).map(z => z.id)).toEqual(['pre_1', 'pre_2', 'post_2']);
-    expect(filterZones(zoneOptions, flightZones, 1).map(z => z.id)).toEqual(['pre_2', 'post_1', 'post_2']);
+
+    augury.mockItems('prx:inventory', invs);
+
+    service.loadInventory().subscribe(inventory => {
+      expect(inventory.length).toEqual(3);
+      expect(inventory[0]).toMatchObject(invs[0]);
+      expect(inventory[1]).toMatchObject(invs[1]);
+      expect(inventory[2]).toMatchObject(invs[2]);
+      done();
+    });
   });
-  it('defaults zone options to the current zone', () => {
-    expect(filterZones(null, flightFixture.zones as InventoryZone[])).toEqual([]);
-    expect(filterZones(null, flightFixture.zones as InventoryZone[], 0)).toEqual(flightFixture.zones);
+
+  it('shows inventory targets', done => {
+    const targets = {
+      inventoryId: 999,
+      episodes: [{ type: 'episode', label: 'Episode 1', code: 'ep1' }],
+      countries: [{ type: 'country', label: 'Canadia', code: 'CA' }]
+    };
+
+    augury.mock('prx:inventory', {}).mock('prx:targets', targets);
+
+    service.loadInventoryTargets(999).subscribe(inventory => {
+      expect(inventory).toMatchObject(targets);
+      done();
+    });
   });
 });

--- a/src/app/core/inventory/inventory.service.ts
+++ b/src/app/core/inventory/inventory.service.ts
@@ -12,7 +12,7 @@ export class InventoryService {
   }
 
   loadInventoryTargets(inventory: number | HalDoc): Observable<HalDoc> {
-    if (inventory instanceof HalDoc) {
+    if (inventory instanceof HalDoc && inventory.follow) {
       return inventory.follow('prx:targets');
     } else {
       return this.augury.follow('prx:inventory', { id: inventory }).follow('prx:targets');

--- a/src/app/core/inventory/inventory.service.ts
+++ b/src/app/core/inventory/inventory.service.ts
@@ -1,81 +1,21 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
 import { HalDoc } from 'ngx-prx-styleguide';
 import { AuguryService } from '../augury.service';
-
-export interface Inventory {
-  id: number;
-  podcastTitle: string;
-  zones: InventoryZone[];
-  self_uri: string;
-}
-
-export interface InventoryZone {
-  id: string;
-  label: string;
-}
-
-// filter zone options to the control at an index
-export const filterZones = (allZones: InventoryZone[], selectedFlightZones: InventoryZone[], zoneIndex?: number) => {
-  selectedFlightZones = selectedFlightZones || [];
-
-  // if allZones is empty/undefined (hasn't loaded yet,) use the flight.zones as options
-  const options = allZones || selectedFlightZones;
-  return options.filter(zone => {
-    if (selectedFlightZones[zoneIndex] && selectedFlightZones[zoneIndex].id === zone.id) {
-      // include currently selected zone
-      return true;
-    } else {
-      // remove zones selected by other controls
-      return !selectedFlightZones.find(z => z.id === zone.id);
-    }
-  });
-};
 
 @Injectable()
 export class InventoryService {
   constructor(private augury: AuguryService) {}
 
-  listInventory(params = {}): Observable<Inventory[]> {
-    return this.augury.followItems('prx:inventory', params).pipe(map(docs => this.docsToInventory(docs)));
+  loadInventory(): Observable<HalDoc[]> {
+    return this.augury.followItems('prx:inventory', { per: 999 });
   }
 
-  docsToInventory(docs: HalDoc[]): Inventory[] {
-    return docs.map(this.docToInventory);
-  }
-
-  docToInventory(doc: HalDoc): Inventory {
-    return {
-      id: doc.id,
-      podcastTitle: doc['podcastTitle'],
-      zones: doc['zones'],
-      self_uri: doc.expand('self')
-    };
-  }
-
-  getInventoryAvailability({
-    id,
-    startDate,
-    endDate,
-    zone,
-    flightId
-  }: {
-    id: string;
-    startDate: string;
-    endDate: string;
-    zone: string;
-    flightId: number;
-  }): Observable<HalDoc> {
-    return this.augury.follow('prx:inventory', { id }).pipe(
-      switchMap(inventory => {
-        return inventory.follow('prx:availability', {
-          startDate,
-          endDate,
-          zone,
-          flightId
-        });
-      })
-    );
+  loadInventoryTargets(inventory: number | HalDoc): Observable<HalDoc> {
+    if (inventory instanceof HalDoc) {
+      return inventory.follow('prx:targets');
+    } else {
+      return this.augury.follow('prx:inventory', { id: inventory }).follow('prx:targets');
+    }
   }
 }

--- a/src/app/shared/css-props/css-props.directive.ts
+++ b/src/app/shared/css-props/css-props.directive.ts
@@ -7,6 +7,7 @@ import { Directive, ElementRef, Input, OnChanges, SimpleChanges } from '@angular
  * Can work for any style properties.
  */
 @Directive({
+  // tslint:disable-next-line
   selector: '[cssProps]'
 })
 export class CSSPropsDirective implements OnChanges {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "esModuleInterop": true,
     "target": "es2015",
     "types": ["jest", "node"],
     "typeRoots": ["node_modules/@types"],


### PR DESCRIPTION
Closes #131 and #133.  Adds optional has-many "Targets" to a Flight.  This implements the "Episode" and "Countries" currently in Augury, but others should be easy to add.

![image](https://user-images.githubusercontent.com/1410587/85157335-93fcd100-b218-11ea-8638-ef5593fe1bdb.png)

- [x] Convert "inventory" options loading to ngrx
- [x] Add "inventory targets" options loading to ngrx
  - Each inventory record has a `prx:targets` link, which is loaded on demand when you navigate to a flight against that inventory.
- [x] UI for adding/removing targets
  - I attempted to do an autocomplete/searchable field for the "code" (Country name or Episode title) ... but I couldn't make it work very well.  Maybe we should take this as new ticket out of this?  For now, I just sort the options.
- [x] Add a "loading" spinner to the inventory table
  - Turns out, previewing "exclude" targets can be slow, and it's a bit hard to see what's going on without a spinner.