### PR TITLE
flight preview switchMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@ngrx/store-devtools": "~8.6.0",
     "angulartics2": "^7.5.2",
     "ngx-prx-styleguide": "3.0.0",
-    "prx-ng-serve": "^3.0.1",
+    "prx-ng-serve": "^3.0.2",
     "rxjs": "~6.5.5",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"

--- a/src/app/campaign/store/effects/flight-preview.effects.ts
+++ b/src/app/campaign/store/effects/flight-preview.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, map, mergeMap } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { FlightPreviewService } from '../../../core';
 import * as flightPreviewActions from '../actions/flight-preview-action.creator';
 
@@ -10,7 +10,7 @@ export class FlightPreviewEffects {
   createFlightPreview$ = createEffect(() =>
     this.actions$.pipe(
       ofType(flightPreviewActions.FlightPreviewCreate),
-      mergeMap(action => {
+      switchMap(action => {
         const { flight, flightDoc, campaignDoc } = action;
         return this.flightPreviewService.createFlightPreview(flight, flightDoc, campaignDoc).pipe(
           map(({ status, statusMessage, days: flightDaysDocs }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7380,10 +7380,10 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-prx-ng-serve@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/prx-ng-serve/-/prx-ng-serve-3.0.1.tgz#ad104e2c6e8cc3fdcce28181cc5f1781e0922488"
-  integrity sha512-E86gVtI4Rph467HMKr52sSDGosIuUNyG2A4/Gxt1gwR+21UFyiffv7n7WsQRvQxPzPuRfIJCDwqG+Eyc0hcyIw==
+prx-ng-serve@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/prx-ng-serve/-/prx-ng-serve-3.0.2.tgz#d4284e4163a8b297179bba3e5ebd811475d31df7"
+  integrity sha512-QIYQQsvB8kUQdNGn/vMJEQDgKOevmMA+/eZ06MNBRwGNcvPVsZTNzrBeSoX8U/dVS3u6nHUaw1qD+VZbiNMuKw==
   dependencies:
     connect-gzip-static "^2.1.1"
     dotenv "^4.0.0"


### PR DESCRIPTION
Closes #203 

If you kick off more than one flight preview post, you'll see the first ones get cancelled and replaced by subsequent posts if they are still ongoing. Previously this was causing those responses to get intermingled, but we only want the last one. (If we wanted the first one and to ignore any subsequent posts, the operator to use would be exaustMap.)