### PR TITLE
211: Add companion toggle to zones

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-    "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "prettier.packageManager": "yarn",
+  "prettier.prettierPath": "./node_modules/prettier",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -92,6 +92,7 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
     endAt: ['', Validators.required],
     contractStartAt: [''],
     contractEndAt: [''],
+    isCompanion: [false],
     zones: this.fb.array([]),
     targets: [''],
     set_inventory_uri: ['', Validators.required],

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -7,13 +7,15 @@
     <div class="inline-fields">
       <mat-form-field appearance="outline">
         <mat-label>Actual Start Date</mat-label>
-        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Actual Start Date" formControlName="startAt" />
+        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Actual Start Date"
+          formControlName="startAt" />
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Actual End Date</mat-label>
-        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="Actual End Date" formControlName="endAt" />
+        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="Actual End Date"
+          formControlName="endAt" />
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
       </mat-form-field>
@@ -21,25 +23,15 @@
     <div class="inline-fields">
       <mat-form-field appearance="outline">
         <mat-label>Contract Start Date</mat-label>
-        <input
-          matInput
-          [matDatepicker]="contractStartPicker"
-          [max]="flight?.contractEndAt"
-          placeholder="Contract Start Date"
-          formControlName="contractStartAt"
-        />
+        <input matInput [matDatepicker]="contractStartPicker" [max]="flight?.contractEndAt"
+          placeholder="Contract Start Date" formControlName="contractStartAt" />
         <mat-datepicker-toggle matSuffix [for]="contractStartPicker"></mat-datepicker-toggle>
         <mat-datepicker #contractStartPicker></mat-datepicker>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Contract End Date</mat-label>
-        <input
-          matInput
-          [matDatepicker]="contractEndPicker"
-          [min]="flight?.contractStartAt"
-          placeholder="Contract End Date"
-          formControlName="contractEndAt"
-        />
+        <input matInput [matDatepicker]="contractEndPicker" [min]="flight?.contractStartAt"
+          placeholder="Contract End Date" formControlName="contractEndAt" />
         <mat-datepicker-toggle matSuffix [for]="contractEndPicker"></mat-datepicker-toggle>
         <mat-datepicker #contractEndPicker></mat-datepicker>
       </mat-form-field>
@@ -50,41 +42,43 @@
         <mat-option *ngFor="let inv of inventory" [value]="inv.self_uri">{{ inv.podcastTitle }}</mat-option>
       </mat-select>
     </mat-form-field>
-    <fieldset class="flight-zones" formArrayName="zones">
-      <h2>Zones</h2>
-      <div *ngFor="let zone of zonesControls.controls; let i = index" [formGroup]="zone" class="inline-fields">
-        <mat-form-field class="zone-name" appearance="outline">
-          <mat-label>Zone Name</mat-label>
-          <mat-select formControlName="id" required>
-            <mat-option *ngFor="let opt of zoneOptionsFiltered(i)" [value]="opt.id">{{ opt.label }}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field appearance="outline">
-          <mat-label>Creative Url</mat-label>
-          <input matInput formControlName="url" autocomplete="off" placeholder="Leave blank for a 0-second MP3" />
-          <mat-error *ngIf="checkInvalidUrl(zone, 'invalidUrl')">Invalid URL</mat-error>
-          <mat-error *ngIf="checkInvalidUrl(zone, 'notMp3')">Must end in mp3</mat-error>
-        </mat-form-field>
-        <div *ngIf="zonesControls?.length > 1" class="remove-zone mat-form-field-wrapper">
-          <button mat-icon-button aria-label="Remove zone" (click)="removeZone.emit(i)">
-            <mat-icon>delete</mat-icon>
-          </button>
+    <div class="flight-zones">
+      <div class="flight-zones-header">
+        <h2>Zones</h2>
+        <mat-slide-toggle formControlName="isCompanion">Companions</mat-slide-toggle>
+      </div>
+      <fieldset formArrayName="zones">
+        <div *ngFor="let zone of zonesControls.controls; let i = index" [formGroup]="zone" class="inline-fields">
+          <mat-form-field class="zone-name" appearance="outline">
+            <mat-label>Zone Name</mat-label>
+            <mat-select formControlName="id" required>
+              <mat-option *ngFor="let opt of zoneOptionsFiltered(i)" [value]="opt.id">{{ opt.label }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field appearance="outline">
+            <mat-label>Creative Url</mat-label>
+            <input matInput formControlName="url" autocomplete="off" placeholder="Leave blank for a 0-second MP3" />
+            <mat-error *ngIf="checkInvalidUrl(zone, 'invalidUrl')">Invalid URL</mat-error>
+            <mat-error *ngIf="checkInvalidUrl(zone, 'notMp3')">Must end in mp3</mat-error>
+          </mat-form-field>
+          <div *ngIf="zonesControls?.length > 1" class="remove-zone mat-form-field-wrapper">
+            <button mat-icon-button aria-label="Remove zone" (click)="removeZone.emit(i)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
         </div>
-      </div>
+      </fieldset>
       <div class="add-zone" *ngIf="zonesControls?.length < zoneOptions?.length">
-        <a mat-button routerLink="." (click)="addZone.emit()"> <mat-icon>add</mat-icon> Add a creative </a>
+        <a mat-button routerLink="." (click)="addZone.emit()">
+          <mat-icon>add</mat-icon> {{ addCreativeLabel }}
+        </a>
       </div>
-    </fieldset>
+    </div>
     <grove-flight-targets formControlName="targets" [targetOptions]="targetOptions"> </grove-flight-targets>
   </div>
   <div class="flight-controls-container">
-    <button
-      (click)="onFlightDeleteToggle()"
-      mat-fab
-      [color]="softDeleted ? 'primary' : 'warn'"
-      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'"
-      *ngIf="canBeDeleted"
-    >
+    <button (click)="onFlightDeleteToggle()" mat-fab [color]="softDeleted ? 'primary' : 'warn'"
+      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'" *ngIf="canBeDeleted">
       <mat-icon>{{ softDeleted ? 'restore_from_trash' : 'delete' }}</mat-icon>
     </button>
     <button (click)="onFlightDuplicate()" mat-fab color="primary" aria-label="Copy flight">

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -7,15 +7,13 @@
     <div class="inline-fields">
       <mat-form-field appearance="outline">
         <mat-label>Actual Start Date</mat-label>
-        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Actual Start Date"
-          formControlName="startAt" />
+        <input matInput [matDatepicker]="startPicker" [max]="flight?.endAt" placeholder="Actual Start Date" formControlName="startAt" />
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Actual End Date</mat-label>
-        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="Actual End Date"
-          formControlName="endAt" />
+        <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="Actual End Date" formControlName="endAt" />
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
       </mat-form-field>
@@ -23,15 +21,25 @@
     <div class="inline-fields">
       <mat-form-field appearance="outline">
         <mat-label>Contract Start Date</mat-label>
-        <input matInput [matDatepicker]="contractStartPicker" [max]="flight?.contractEndAt"
-          placeholder="Contract Start Date" formControlName="contractStartAt" />
+        <input
+          matInput
+          [matDatepicker]="contractStartPicker"
+          [max]="flight?.contractEndAt"
+          placeholder="Contract Start Date"
+          formControlName="contractStartAt"
+        />
         <mat-datepicker-toggle matSuffix [for]="contractStartPicker"></mat-datepicker-toggle>
         <mat-datepicker #contractStartPicker></mat-datepicker>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Contract End Date</mat-label>
-        <input matInput [matDatepicker]="contractEndPicker" [min]="flight?.contractStartAt"
-          placeholder="Contract End Date" formControlName="contractEndAt" />
+        <input
+          matInput
+          [matDatepicker]="contractEndPicker"
+          [min]="flight?.contractStartAt"
+          placeholder="Contract End Date"
+          formControlName="contractEndAt"
+        />
         <mat-datepicker-toggle matSuffix [for]="contractEndPicker"></mat-datepicker-toggle>
         <mat-datepicker #contractEndPicker></mat-datepicker>
       </mat-form-field>
@@ -69,16 +77,19 @@
         </div>
       </fieldset>
       <div class="add-zone" *ngIf="zonesControls?.length < zoneOptions?.length">
-        <a mat-button routerLink="." (click)="addZone.emit()">
-          <mat-icon>add</mat-icon> {{ addCreativeLabel }}
-        </a>
+        <a mat-button routerLink="." (click)="addZone.emit()"> <mat-icon>add</mat-icon> {{ addCreativeLabel }} </a>
       </div>
     </div>
     <grove-flight-targets formControlName="targets" [targetOptions]="targetOptions"> </grove-flight-targets>
   </div>
   <div class="flight-controls-container">
-    <button (click)="onFlightDeleteToggle()" mat-fab [color]="softDeleted ? 'primary' : 'warn'"
-      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'" *ngIf="canBeDeleted">
+    <button
+      (click)="onFlightDeleteToggle()"
+      mat-fab
+      [color]="softDeleted ? 'primary' : 'warn'"
+      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'"
+      *ngIf="canBeDeleted"
+    >
       <mat-icon>{{ softDeleted ? 'restore_from_trash' : 'delete' }}</mat-icon>
     </button>
     <button (click)="onFlightDuplicate()" mat-fab color="primary" aria-label="Copy flight">

--- a/src/app/campaign/flight/flight-form.component.scss
+++ b/src/app/campaign/flight/flight-form.component.scss
@@ -73,3 +73,9 @@ mat-card {
     }
   }
 }
+
+.flight-zones-header {
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  grid-gap: 1rem;
+}

--- a/src/app/campaign/flight/flight-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-form.component.spec.ts
@@ -10,6 +10,7 @@ import {
   MatButtonModule,
   MatIconModule,
   MatDatepickerModule,
+  MatSlideToggleModule,
   DateAdapter,
   MAT_DATE_LOCALE,
   MAT_DATE_FORMATS
@@ -85,7 +86,8 @@ class ParentFormComponent {
     contractEndAt: [''],
     zones: this.fb.array([this.fb.group({ id: ['', Validators.required], url: ['', validateMp3] })]),
     targets: [''],
-    set_inventory_uri: ['', Validators.required]
+    set_inventory_uri: ['', Validators.required],
+    isCompanion: [false]
   });
 }
 
@@ -107,7 +109,8 @@ describe('FlightFormComponent', () => {
         MatDatepickerModule,
         MatMomentDateModule,
         MatButtonModule,
-        MatIconModule
+        MatIconModule,
+        MatSlideToggleModule
       ],
       declarations: [ParentFormComponent, FlightFormComponent, FlightTargetsFormComponent],
       providers: [

--- a/src/app/campaign/flight/flight-form.component.ts
+++ b/src/app/campaign/flight/flight-form.component.ts
@@ -49,4 +49,9 @@ export class FlightFormComponent implements OnInit {
   get canBeDeleted(): boolean {
     return this.flight && !this.flight.actualCount;
   }
+
+  get addCreativeLabel(): string {
+    const type = this.flight.isCompanion ? 'companion' : 'creative';
+    return `Add a ${type}`;
+  }
 }

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -111,7 +111,7 @@ export class CampaignActionService implements OnDestroy {
   }
 
   havePreviewParamsChanged(a: Flight, b: Flight) {
-    const check = ['startAt', 'endAt', 'set_inventory_uri', 'zones', 'targets', 'totalGoal', 'dailyMinimum', 'deliveryMode'];
+    const check = ['startAt', 'endAt', 'set_inventory_uri', 'zones', 'targets', 'totalGoal', 'dailyMinimum', 'deliveryMode', 'isCompanion'];
     return check.some(fld => {
       if (this.hasChanged(b[fld], a[fld])) {
         // console.log(`previewing BECAUSE ${fld}:`, a[fld], '->', b[fld]);

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -35,6 +35,7 @@ export interface Flight {
   contractGoal?: number;
   contractStartAt?: Moment;
   contractEndAt?: Moment;
+  isCompanion?: boolean;
 }
 
 export interface FlightState {


### PR DESCRIPTION
Closes #211 

### This PR...
- Adds slide toggle input for `isCompanion` prop to flight form.
- Adds `isCompanion` to Flight model.
- Adds `isCompanion` to the props that trigger an allocation preview.
- Updates flight-form spec.