### PR TITLE
validates flight dates against actuals served

### DIFF
--- a/src/app/campaign/flight/flight-form-control-container.component.spec.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.spec.ts
@@ -130,4 +130,23 @@ describe('FlightFormControlContainerComponent', () => {
     component.softDeleted = false;
     expect(component.flightForm.get('name').disabled).toEqual(false);
   });
+
+  it('should validate flight start and end at', () => {
+    component.flightForm.patchValue(flightFixture);
+    expect(component.flightForm.valid).toBeTruthy();
+    component.flightActualsDateBoundaries = {
+      startAt: moment
+        .utc()
+        .subtract(7, 'days')
+        .toDate(),
+      endAt: moment.utc().toDate()
+    };
+    component.flightForm.get('startAt').setValue(moment.utc().subtract(4, 'days'));
+    component.flightForm.get('startAt').markAsTouched();
+    component.flightForm.get('endAtFudged').setValue(moment.utc().subtract(2, 'days'));
+    component.flightForm.get('endAtFudged').markAsTouched();
+    expect(component.validateStartAt(component.flightForm.get('startAt')).error).toBeDefined();
+    expect(component.validateEndAt(component.flightForm.get('endAtFudged')).error).toBeDefined();
+    expect(component.flightForm.invalid).toBeTruthy();
+  });
 });

--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -146,7 +146,7 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
 
   // updates the form from @Input() set flight
   setFlightForm(flight: Flight) {
-    // reset the form
-    this.flightForm.reset(flight, { emitEvent: false });
+    // patch values onto the form
+    this.flightForm.patchValue(flight, { emitEvent: false });
   }
 }

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -13,15 +13,18 @@
           [max]="flight?.endAtFudged"
           placeholder="Actual Start Date"
           formControlName="startAt"
+          [errorStateMatcher]="matcher"
         />
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker></mat-datepicker>
+        <mat-error *ngIf="checkError('startAt') as error">{{ error }}</mat-error>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Actual End Date</mat-label>
         <input matInput [matDatepicker]="endPicker" [min]="flight?.startAt" placeholder="Actual End Date" formControlName="endAtFudged" />
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker></mat-datepicker>
+        <mat-error *ngIf="checkError('endAtFudged') as error">{{ error }}</mat-error>
       </mat-form-field>
     </div>
     <div class="inline-fields">

--- a/src/app/campaign/flight/flight-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-form.component.spec.ts
@@ -47,6 +47,9 @@ const flightFixture: Flight = {
   set_inventory_uri: '/some/inventory',
   deliveryMode: 'capped'
 };
+
+// arbitrary validator to produce an error for spec
+export const cannotStartInPast = control => (control.value.valueOf() > Date.now() ? { error: 'start date cannot be in the past' } : null);
 @Component({
   template: `
     <form [formGroup]="flightForm">
@@ -81,7 +84,7 @@ class ParentFormComponent {
   flightForm = this.fb.group({
     id: [],
     name: ['', Validators.required],
-    startAt: ['', Validators.required],
+    startAt: ['', [Validators.required, cannotStartInPast]],
     endAtFudged: ['', Validators.required],
     contractStartAt: [''],
     contractEndAt: [''],
@@ -142,5 +145,11 @@ describe('FlightFormComponent', () => {
   it('emits flight delete toggle', done => {
     component.flightDeleteToggle.subscribe(() => done());
     component.onFlightDeleteToggle();
+  });
+
+  it('checks for flight form errors', () => {
+    component.flightForm.get('startAt').setValue(moment.utc().subtract(2, 'days'));
+    component.flightForm.get('startAt').markAsTouched();
+    expect(component.checkError('startAt')).toBeDefined();
   });
 });

--- a/src/app/campaign/flight/flight-form.component.ts
+++ b/src/app/campaign/flight/flight-form.component.ts
@@ -1,7 +1,13 @@
 import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
-import { FormGroup, FormArray, AbstractControl, ControlContainer } from '@angular/forms';
-import { Flight, FlightZone, Inventory, InventoryZone, InventoryTargets, filterZones } from '../store/models';
+import { FormGroup, AbstractControl, ControlContainer } from '@angular/forms';
+import { ErrorStateMatcher } from '@angular/material';
+import { Flight, FlightZone, Inventory, InventoryZone, InventoryTargets } from '../store/models';
 
+export class FlightFormErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(control: AbstractControl): boolean {
+    return control && control.invalid && (control.dirty || control.touched);
+  }
+}
 @Component({
   selector: 'grove-flight-form',
   templateUrl: './flight-form.component.html',
@@ -19,6 +25,7 @@ export class FlightFormComponent implements OnInit {
   @Output() addZone = new EventEmitter<{ flightId: number; zone: FlightZone }>();
   @Output() removeZone = new EventEmitter<{ flightId: number; index: number }>();
   flightForm: FormGroup;
+  matcher = new FlightFormErrorStateMatcher();
 
   ngOnInit() {
     this.flightForm = this.formContainer.control as FormGroup;
@@ -44,5 +51,9 @@ export class FlightFormComponent implements OnInit {
 
   onRemoveZone({ index }: { index: number }) {
     this.removeZone.emit({ flightId: this.flight.id, index });
+  }
+
+  checkError(fieldName: string, type = 'error') {
+    return this.flightForm.get(fieldName).getError(type);
   }
 }

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -13,7 +13,8 @@ import {
   selectIsFlightPreviewLoading,
   selectAllInventoryOrderByName,
   selectCurrentInventoryZones,
-  selectCurrentInventoryTargets
+  selectCurrentInventoryTargets,
+  selectFlightActualsDateBoundaries
 } from '../store/selectors';
 import { CampaignActionService } from '../store/actions/campaign-action.service';
 
@@ -29,6 +30,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
       [isPreview]="isPreview$ | async"
       [isLoading]="isLoading$ | async"
       [previewError]="flightPreviewError$ | async"
+      [flightActualsDateBoundaries]="flightActualsDateBoundaries$ | async"
       (flightUpdate)="flightUpdateFromForm($event)"
       (flightDeleteToggle)="flightDeleteToggle()"
       (flightDuplicate)="flightDuplicate($event)"
@@ -50,6 +52,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
   inventoryOptions$: Observable<Inventory[]>;
   zoneOptions$: Observable<InventoryZone[]>;
   targetOptions$: Observable<InventoryTargets>;
+  flightActualsDateBoundaries$: Observable<{ startAt: Date; endAt: Date }>;
   flightSub: Subscription;
 
   constructor(private store: Store<any>, private campaignAction: CampaignActionService) {}
@@ -66,6 +69,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
     this.inventoryOptions$ = this.store.pipe(select(selectAllInventoryOrderByName));
     this.zoneOptions$ = this.store.pipe(select(selectCurrentInventoryZones));
     this.targetOptions$ = this.store.pipe(select(selectCurrentInventoryTargets));
+    this.flightActualsDateBoundaries$ = this.store.pipe(select(selectFlightActualsDateBoundaries));
   }
 
   ngOnDestroy() {

--- a/src/app/campaign/store/selectors/flight-days.selectors.ts
+++ b/src/app/campaign/store/selectors/flight-days.selectors.ts
@@ -141,8 +141,5 @@ export const selectFlightActualsDateBoundaries = createSelector(selectRoutedFlig
     flightDays &&
     flightDays.days &&
     [...flightDays.days].sort((a, b) => b.date.valueOf() - a.date.valueOf()).find(day => day.numbers.actuals > 0);
-  if (startAt && endAt) {
-    console.log({ startAt: startAt.date, endAt: endAt.date });
-  }
   return startAt && endAt ? { startAt: startAt.date, endAt: endAt.date } : null;
 });

--- a/src/app/campaign/store/selectors/flight-days.selectors.ts
+++ b/src/app/campaign/store/selectors/flight-days.selectors.ts
@@ -131,3 +131,18 @@ export const selectFlightDaysRollup = createSelector(
     return flightDays && flightDays.days && rollupWeeks(flightDays.days);
   }
 );
+
+export const selectFlightActualsDateBoundaries = createSelector(selectRoutedFlightDays, (flightDays): { startAt: Date; endAt: Date } => {
+  const startAt =
+    flightDays &&
+    flightDays.days &&
+    [...flightDays.days].sort((a, b) => a.date.valueOf() - b.date.valueOf()).find(day => day.numbers.actuals > 0);
+  const endAt =
+    flightDays &&
+    flightDays.days &&
+    [...flightDays.days].sort((a, b) => b.date.valueOf() - a.date.valueOf()).find(day => day.numbers.actuals > 0);
+  if (startAt && endAt) {
+    console.log({ startAt: startAt.date, endAt: endAt.date });
+  }
+  return startAt && endAt ? { startAt: startAt.date, endAt: endAt.date } : null;
+});


### PR DESCRIPTION
Closes #75 

Validates the flight start and end dates to be within the dates that actuals have been served. It doesn't stop the preview request on flight date change, which also gives the same error, but it does prevent the flight from being saved because of an invalid form.

Flight form fields were getting touched reset on form updates because of the use of `reset` in the incoming form updates, so the validation errors would flash up but then go away. I changed that `reset` to `patchValue` to resolve this. Maybe when the flight id changes, the form controls could be reset when updating the values to the routed flight if it hasn't been changed, but probably the correct way to have done this would have been to have all the flight forms in a single parent form group instead of swapping out the one form's values.