### PR TITLE
campaign form save error handling

### DIFF
--- a/src/app/campaign/campaign-error.service.ts
+++ b/src/app/campaign/campaign-error.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { select, Store } from '@ngrx/store';
+import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { selectError } from './store/selectors';
+import * as campaignActions from './store/actions/campaign-action.creator';
+
+@Injectable()
+export class CampaignErrorService implements OnDestroy {
+  errorSub: Subscription;
+
+  constructor(private snackBar: MatSnackBar, private store: Store<any>) {
+    this.errorSub = this.store.pipe(select(selectError)).subscribe(this.onCampaignError.bind(this));
+  }
+
+  onCampaignError(error: any) {
+    if (error) {
+      this.snackBar
+        .open(error, 'Dismiss')
+        .onAction()
+        .pipe(take(1))
+        .subscribe(() => this.onDismissError());
+    }
+  }
+
+  onDismissError() {
+    this.store.dispatch(campaignActions.CampaignDismissError());
+  }
+
+  ngOnDestroy() {
+    this.snackBar.dismiss();
+    this.onDismissError();
+    if (this.errorSub) {
+      this.errorSub.unsubscribe();
+    }
+  }
+}

--- a/src/app/campaign/campaign.component.spec.ts
+++ b/src/app/campaign/campaign.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MatSidenavModule, MatListModule, MatIconModule, MatProgressSpinnerModule, MatMenuModule } from '@angular/material';
+import { MatIconModule, MatListModule, MatMenuModule, MatProgressSpinnerModule, MatSidenavModule } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreRouterConnectingModule, routerReducer } from '@ngrx/router-store';
@@ -19,6 +19,7 @@ import * as campaignActions from './store/actions/campaign-action.creator';
 import { CampaignComponent } from './campaign.component';
 import { CampaignStatusComponent } from './status/campaign-status.component';
 import { CampaignNavComponent } from './nav/campaign-nav.component';
+import { CampaignErrorService } from './campaign-error.service';
 import { TestComponent, campaignRoutes } from '../../testing/test.component';
 import { campaignFixture, flightFixture } from './store/models/campaign-state.factory';
 
@@ -56,9 +57,9 @@ describe('CampaignComponent', () => {
         NoopAnimationsModule,
         MatIconModule,
         MatListModule,
+        MatMenuModule,
         MatProgressSpinnerModule,
-        MatSidenavModule,
-        MatMenuModule
+        MatSidenavModule
       ],
       declarations: [CampaignComponent, CampaignNavComponent, CampaignStatusComponent, TestComponent],
       providers: [
@@ -73,6 +74,10 @@ describe('CampaignComponent', () => {
         {
           provide: InventoryService,
           useValue: { listInventory: jest.fn(() => of([])) }
+        },
+        {
+          provide: CampaignErrorService,
+          userValue: {}
         },
         CampaignActionService
       ]
@@ -111,7 +116,7 @@ describe('CampaignComponent', () => {
       jest.spyOn(store, 'dispatch');
     });
     it('calls action to duplicate a campaign by id', done => {
-      // id is passed through the /camp[aign/new router link state
+      // id is passed through the /campaign/new router link state
       Object.defineProperty(window.history, 'state', { writable: true, value: { id: 123 } });
       fix.ngZone.run(() => {
         router.navigateByUrl('/campaign/new');

--- a/src/app/campaign/campaign.component.ts
+++ b/src/app/campaign/campaign.component.ts
@@ -4,7 +4,6 @@ import { Observable, Subscription } from 'rxjs';
 import { Store, select } from '@ngrx/store';
 import { FlightState, Campaign } from './store/models';
 import {
-  selectError,
   selectLocalCampaign,
   selectCampaignLoaded,
   selectCampaignLoading,
@@ -20,6 +19,7 @@ import * as advertiserActions from './store/actions/advertiser-action.creator';
 import * as campaignActions from './store/actions/campaign-action.creator';
 import * as inventoryActions from './store/actions/inventory-action.creator';
 import { CampaignActionService } from './store/actions/campaign-action.service';
+import { CampaignErrorService } from './campaign-error.service';
 
 @Component({
   selector: 'grove-campaign',
@@ -47,10 +47,7 @@ import { CampaignActionService } from './store/actions/campaign-action.service';
       </mat-drawer>
       <mat-drawer-content role="main">
         <ng-container *ngIf="campaignLoaded$ | async; else loading">
-          <div class="error" *ngIf="error$ | async as error; else content">{{ error }}</div>
-          <ng-template #content>
-            <router-outlet></router-outlet>
-          </ng-template>
+          <router-outlet></router-outlet>
         </ng-container>
         <ng-template #loading>
           <div class="loading" *ngIf="campaignLoading$ | async"><mat-spinner></mat-spinner></div>
@@ -67,14 +64,18 @@ export class CampaignComponent implements OnInit, OnDestroy {
   campaignLoaded$: Observable<boolean>;
   campaignLoading$: Observable<boolean>;
   campaignSaving$: Observable<boolean>;
-  error$: Observable<any>;
   valid$: Observable<boolean>;
   changed$: Observable<boolean>;
   campaignName$: Observable<string>;
   campaignActualCount$: Observable<number>;
   routeSub: Subscription;
 
-  constructor(private route: ActivatedRoute, private store: Store<any>, private campaignActionService: CampaignActionService) {}
+  constructor(
+    private route: ActivatedRoute,
+    private store: Store<any>,
+    private campaignActionService: CampaignActionService,
+    private campaignErrorService: CampaignErrorService
+  ) {}
 
   ngOnInit() {
     this.store.dispatch(accountActions.AccountsLoad());
@@ -99,7 +100,6 @@ export class CampaignComponent implements OnInit, OnDestroy {
     this.campaignLoaded$ = this.store.pipe(select(selectCampaignLoaded));
     this.campaignLoading$ = this.store.pipe(select(selectCampaignLoading));
     this.campaignSaving$ = this.store.pipe(select(selectCampaignSaving));
-    this.error$ = this.store.pipe(select(selectError));
     this.campaignName$ = this.store.pipe(select(selectLocalCampaignName));
     this.campaignActualCount$ = this.store.pipe(select(selectLocalCampaignActualCount));
     this.flights$ = this.store.pipe(select(selectAllFlightsOrderByCreatedAt));

--- a/src/app/campaign/campaign.module.ts
+++ b/src/app/campaign/campaign.module.ts
@@ -14,6 +14,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatSnackBarModule, MAT_SNACK_BAR_DEFAULT_OPTIONS } from '@angular/material/snack-bar';
 import { StatusBarModule, FancyFormModule } from 'ngx-prx-styleguide';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
@@ -25,6 +26,7 @@ import { CampaignEffects } from './store/effects/campaign.effects';
 import { FlightPreviewEffects } from './store/effects/flight-preview.effects';
 import { InventoryEffects } from './store/effects/inventory.effects';
 import { CampaignActionService } from './store/actions/campaign-action.service';
+import { CampaignErrorService } from './campaign-error.service';
 import { campaignRouting, campaignComponents } from './campaign.routing';
 
 @NgModule({
@@ -44,6 +46,7 @@ import { campaignRouting, campaignComponents } from './campaign.routing';
     MatListModule,
     MatProgressSpinnerModule,
     MatMenuModule,
+    MatSnackBarModule,
     CommonModule,
     ReactiveFormsModule,
     StatusBarModule,
@@ -52,6 +55,10 @@ import { campaignRouting, campaignComponents } from './campaign.routing';
     StoreModule.forFeature('campaignState', fromCampaignState.reducers, { metaReducers: fromCampaignState.metaReducers }),
     EffectsModule.forFeature([AccountEffects, AdvertiserEffects, CampaignEffects, FlightPreviewEffects, InventoryEffects])
   ],
-  providers: [CampaignActionService]
+  providers: [
+    CampaignActionService,
+    CampaignErrorService,
+    { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { horizontalPosition: 'center', verticalPosition: 'top' } }
+  ]
 })
 export class CampaignModule {}

--- a/src/app/campaign/store/actions/action.types.ts
+++ b/src/app/campaign/store/actions/action.types.ts
@@ -15,6 +15,7 @@ export enum ActionTypes {
   CAMPAIGN_DELETE = '[Campaign] Campaign Delete',
   CAMPAIGN_DELETE_SUCCESS = '[Campaign] Campaign Delete Success',
   CAMPAIGN_DELETE_FAILURE = '[Campaign] Campaign Delete Failure',
+  CAMPAIGN_DISMISS_ERROR = '[Campaign] Dismiss Error',
   CAMPAIGN_ADD_FLIGHT = '[Campaign] Add Flight',
   CAMPAIGN_ADD_FLIGHT_WITH_TEMP_ID = '[Campaign] Add Flight With Temp Id',
   CAMPAIGN_DUP_FLIGHT = '[Campaign] Dup Flight',

--- a/src/app/campaign/store/actions/campaign-action.creator.ts
+++ b/src/app/campaign/store/actions/campaign-action.creator.ts
@@ -69,6 +69,8 @@ export const CampaignDelete = createAction(ActionTypes.CAMPAIGN_DELETE, props<{ 
 export const CampaignDeleteSuccess = createAction(ActionTypes.CAMPAIGN_DELETE_SUCCESS, props<{ id: number | string }>());
 export const CampaignDeleteFailure = createAction(ActionTypes.CAMPAIGN_DELETE_FAILURE, props<{ error }>());
 
+export const CampaignDismissError = createAction(ActionTypes.CAMPAIGN_DISMISS_ERROR);
+
 export const CampaignAddFlight = createAction(
   ActionTypes.CAMPAIGN_ADD_FLIGHT,
   ({ campaignId, flightId, startAt, endAt }: { campaignId: number | string; flightId?: number; startAt?: Moment; endAt?: Moment }) => {
@@ -131,6 +133,7 @@ const all = union({
   CampaignDelete,
   CampaignDeleteSuccess,
   CampaignDeleteFailure,
+  CampaignDismissError,
   CampaignFlightFormUpdate,
   CampaignAddFlight,
   CampaignDupFlight,

--- a/src/app/campaign/store/reducers/campaign.reducer.ts
+++ b/src/app/campaign/store/reducers/campaign.reducer.ts
@@ -109,6 +109,10 @@ const _reducer = createReducer(
   on(campaignActions.CampaignDeleteFailure, (state, action) => ({
     ...state,
     error: action.error
+  })),
+  on(campaignActions.CampaignDismissError, (state, action) => ({
+    ...state,
+    error: null
   }))
 );
 

--- a/src/app/campaign/store/selectors/campaign-flight.selectors.ts
+++ b/src/app/campaign/store/selectors/campaign-flight.selectors.ts
@@ -54,9 +54,13 @@ export const selectFlightNotFoundError = createSelector(
   (loaded, flightId, flights): string => loaded && flightId && !flights[flightId] && 'Flight Not Found'
 );
 
-export const selectError = createSelector(selectCampaignError, selectFlightNotFoundError, (campaignError: any, flightError: string) => {
-  return (campaignError && campaignError.body && campaignError.body.message && 'Campaign ' + campaignError.body.message) || flightError;
-});
+export const selectError = createSelector(
+  selectCampaignError,
+  selectFlightNotFoundError,
+  (campaignError: any, flightNotFoundError: string) => {
+    return (campaignError && campaignError.body && campaignError.body.message) || flightNotFoundError;
+  }
+);
 
 export const selectRoutedCampaignFlightDocs = createSelector(
   selectCampaign,


### PR DESCRIPTION
Closes #222 

* Adds a Material Snackbar notification for campaign errors. These errors could show up for errors on campaign form save, delete, or duplicate campaign by id not found.
* On campaign form save, if campaign creation succeeds but there is an error on flight creation, shows the error notification and navigates to the new campaign id. It's possible to generate this error situation if you do something invalid with the flight like use a 404 mp3 zone url.