### PR TITLE
form array guard and other fixes

### DIFF
--- a/src/app/campaign/flight/flight-targets-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.spec.ts
@@ -154,4 +154,10 @@ describe('FlightTargetsFormComponent', () => {
     };
     expect(component.targetOptionsMap.episode[0].label).toEqual('2/12/2020 - Ep A');
   });
+
+  it('does not emit while receiving incoming update', () => {
+    jest.spyOn(component, 'onChangeFn');
+    component.writeValue([{ type: 'country', code: 'US', exclude: false }]);
+    expect(component.onChangeFn).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/campaign/flight/flight-targets-form.component.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.ts
@@ -110,7 +110,6 @@ export class FlightTargetsFormComponent implements ControlValueAccessor, OnDestr
   targets: { type: string; options$: Observable<InventoryTarget[]> }[] = [];
   targetsForm: FormArray;
   targetsFormSub: Subscription;
-  emitGuard = false;
   onChangeFn = (value: any) => {};
   onTouchedFn = (value: any) => {};
 
@@ -130,8 +129,6 @@ export class FlightTargetsFormComponent implements ControlValueAccessor, OnDestr
     // there is something in the spec that could be done differently to not
     // require this check.
     if (Array.isArray(targets)) {
-      // don't emit while manipulating FormArray with incoming update
-      this.emitGuard = true;
       // Clean up subscriptions and previous form groups.
       if (this.targetsFormSub) {
         this.unsubscribeFromTargetsForm();
@@ -147,13 +144,10 @@ export class FlightTargetsFormComponent implements ControlValueAccessor, OnDestr
         formGroups.push(formGroup);
       });
       this.targetsForm = new FormArray(formGroups);
-      this.emitGuard = false;
       // Create new subscription for form changes.
       this.targetsFormSub = this.targetsForm.valueChanges.subscribe(formTargets => {
         const changes = formTargets.map(this.flightTargetOutput.bind(this));
-        if (!this.emitGuard) {
-          this.onChangeFn(changes);
-        }
+        this.onChangeFn(changes);
       });
     }
   }

--- a/src/app/campaign/flight/flight-targets-form.component.ts
+++ b/src/app/campaign/flight/flight-targets-form.component.ts
@@ -110,6 +110,7 @@ export class FlightTargetsFormComponent implements ControlValueAccessor, OnDestr
   targets: { type: string; options$: Observable<InventoryTarget[]> }[] = [];
   targetsForm: FormArray;
   targetsFormSub: Subscription;
+  emitGuard = false;
   onChangeFn = (value: any) => {};
   onTouchedFn = (value: any) => {};
 
@@ -129,6 +130,8 @@ export class FlightTargetsFormComponent implements ControlValueAccessor, OnDestr
     // there is something in the spec that could be done differently to not
     // require this check.
     if (Array.isArray(targets)) {
+      // don't emit while manipulating FormArray with incoming update
+      this.emitGuard = true;
       // Clean up subscriptions and previous form groups.
       if (this.targetsFormSub) {
         this.unsubscribeFromTargetsForm();
@@ -144,10 +147,13 @@ export class FlightTargetsFormComponent implements ControlValueAccessor, OnDestr
         formGroups.push(formGroup);
       });
       this.targetsForm = new FormArray(formGroups);
+      this.emitGuard = false;
       // Create new subscription for form changes.
       this.targetsFormSub = this.targetsForm.valueChanges.subscribe(formTargets => {
         const changes = formTargets.map(this.flightTargetOutput.bind(this));
-        this.onChangeFn(changes);
+        if (!this.emitGuard) {
+          this.onChangeFn(changes);
+        }
       });
     }
   }

--- a/src/app/campaign/flight/flight-zones-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.spec.ts
@@ -113,4 +113,21 @@ describe('FlightZonesFormComponent', () => {
     expect(urlField.errors).toEqual({ notMp3: { value: 'http://this.is/notaudio.jpg' } });
     expect(zone.get('url').hasError('notMp3')).toEqual(true);
   });
+
+  it('does not emit while receiving incoming update', () => {
+    jest.spyOn(component, 'onChangeFn');
+    component.writeValue([{ id: 'pre_1' }, { id: 'pre_2' }]);
+    expect(component.onChangeFn).not.toHaveBeenCalled();
+    component.writeValue([{ id: 'pre_1' }]);
+    expect(component.onChangeFn).not.toHaveBeenCalled();
+  });
+
+  it('clears controls for empty zone', () => {
+    component.writeValue([{ id: 'pre_1', url: 'http://this.looks/valid.mp3' }]);
+    expect(component.zones.controls[0].get('id').value).toEqual('pre_1');
+    expect(component.zones.controls[0].get('url').value).toEqual('http://this.looks/valid.mp3');
+    component.writeValue([]);
+    expect(component.zones.controls[0].get('id').value).toEqual('');
+    expect(component.zones.controls[0].get('url').value).toEqual('');
+  });
 });

--- a/src/app/campaign/flight/flight-zones-form.component.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.ts
@@ -120,7 +120,7 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnDestroy
       this.zones.markAsPristine();
     }
     // patch all of the values onto the FormArray
-    this.zones.patchValue(zones || [], { emitEvent: false });
+    this.zones.patchValue(zones, { emitEvent: false, onlySelf: true });
     this.emitGuard = false;
   }
 

--- a/src/app/campaign/flight/flight-zones-form.component.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.ts
@@ -108,13 +108,13 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnDestroy
     // don't emit while manipulating FormArray with incoming update
     this.emitGuard = true;
     // get the correct number of zone fields and patchValue
-    const expectedLength = zones.length || 1;
-    while (this.zones.controls.length > expectedLength) {
+    zones = zones && zones.length ? zones : [{ id: '', url: '' }];
+    while (this.zones.controls.length > zones.length) {
       this.zones.removeAt(this.zones.controls.length - 1);
       this.zones.markAsPristine();
     }
     const addZones = [...zones];
-    while (this.zones.controls.length < expectedLength) {
+    while (this.zones.controls.length < zones.length) {
       // this only adds controls, doesnt reset controls already in form
       this.zones.push(this.flightZoneFormGroup(zones && addZones.pop()));
       this.zones.markAsPristine();

--- a/src/app/campaign/flight/flight-zones-form.component.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.ts
@@ -45,7 +45,13 @@ export const validateMp3 = (value: string): { [key: string]: any } | null => {
         </mat-form-field>
         <mat-form-field appearance="outline">
           <mat-label>Creative Url</mat-label>
-          <input matInput formControlName="url" autocomplete="off" placeholder="Leave blank for a 0-second MP3" />
+          <input
+            matInput
+            [errorStateMatcher]="matcher"
+            formControlName="url"
+            autocomplete="off"
+            placeholder="Leave blank for a 0-second MP3"
+          />
           <mat-error *ngIf="checkInvalidUrl(zone, 'invalidUrl')">Invalid URL</mat-error>
           <mat-error *ngIf="checkInvalidUrl(zone, 'notMp3')">Must end in mp3</mat-error>
         </mat-form-field>

--- a/src/app/campaign/flight/flight-zones-form.component.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.ts
@@ -76,8 +76,11 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnDestroy
   matcher = new ZonesErrorStateMatcher();
   zones = new FormArray([].map(this.flightZoneFormGroup));
   zonesSub = this.zones.valueChanges.subscribe(formZones => {
-    this.onChangeFn(formZones);
+    if (!this.emitGuard) {
+      this.onChangeFn(formZones);
+    }
   });
+  emitGuard = false;
   onChangeFn = (value: any) => {};
   onTouchedFn = (value: any) => {};
 
@@ -96,6 +99,8 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnDestroy
   }
 
   writeValue(zones: FlightZone[]) {
+    // don't emit while manipulating FormArray with incoming update
+    this.emitGuard = true;
     // get the correct number of zone fields and patchValue
     const expectedLength = zones.length || 1;
     while (this.zones.controls.length > expectedLength) {
@@ -110,6 +115,7 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnDestroy
     }
     // patch all of the values onto the FormArray
     this.zones.patchValue(zones || [], { emitEvent: false });
+    this.emitGuard = false;
   }
 
   registerOnChange(fn: (value: any) => void) {

--- a/src/app/campaign/store/actions/campaign-action.service.spec.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.spec.ts
@@ -18,7 +18,7 @@ import {
 import { MockHalDoc } from 'ngx-prx-styleguide';
 import { TestComponent, campaignRoutes } from '../../../../testing/test.component';
 import { CampaignActionService } from './campaign-action.service';
-import * as moment from 'moment';
+import moment from 'moment';
 
 describe('CampaignActionService', () => {
   let router: Router;
@@ -171,6 +171,12 @@ describe('CampaignActionService', () => {
       expect(service.hasChanged({ one: 1, two: 2 }, { one: 1 })).toEqual(true);
     });
 
+    it('compares moments', () => {
+      const date1 = moment.utc();
+      const date2 = moment(date1.valueOf());
+      expect(service.hasChanged(date1, date2)).toEqual(false);
+    });
+
     it('compares other stuff', () => {
       expect(service.hasChanged('a', 'a')).toEqual(false);
       expect(service.hasChanged('a', 'b')).toEqual(true);
@@ -207,6 +213,11 @@ describe('CampaignActionService', () => {
     it('should load flight preview when total goal is changed', () => {
       service.updateFlightForm({ ...flightFixture, endAt: moment.utc() }, true, true);
       expect(service.loadFlightPreview).toHaveBeenCalled();
+    });
+
+    it('should not load flight preview if routed flight id is different from form flight id (route transition)', () => {
+      service.updateFlightForm({ ...flightFixture, id: 1234, totalGoal: 10 }, true, true);
+      expect(service.loadFlightPreview).not.toHaveBeenCalled();
     });
 
     it('should load flight preview when delivery mode is changed', () => {

--- a/src/app/campaign/store/actions/campaign-action.service.ts
+++ b/src/app/campaign/store/actions/campaign-action.service.ts
@@ -31,6 +31,8 @@ export class CampaignActionService implements OnDestroy {
     map(this.transformFlightForm),
     // if preview params changed, dispatch loadFlightPreview
     withLatestFrom(this.store.pipe(select(selectRoutedFlight))),
+    // re-using the flight form, so check that ids match
+    filter(([formState, flightState]) => !flightState || !flightState.localFlight || formState.flight.id === flightState.localFlight.id),
     tap(([formState, flightState]) => {
       if (
         this.hasPreviewParams(formState.flight) &&

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -58,9 +58,14 @@ export const docToFlight = (doc: HalDoc): Flight => {
     endAtFudged: utc(flight.endAt).subtract(1, 'days'),
     createdAt: new Date(flight.createdAt),
     set_inventory_uri: doc.expand('prx:inventory'),
-    ...(flight.contractStartAt && { contractStartAt: utc(flight.contractStartAt) }),
-    ...(flight.contractEndAt && { contractEndAt: utc(flight.contractEndAt) }),
-    ...(flight.contractEndAt && { contractEndAtFudged: utc(flight.contractEndAt).subtract(1, 'days') })
+    contractStartAt: flight.contractStartAt ? utc(flight.contractStartAt) : null,
+    contractEndAt: flight.contractEndAt ? utc(flight.contractEndAt) : null,
+    contractEndAtFudged: flight.contractEndAt ? utc(flight.contractEndAt).subtract(1, 'days') : null,
+    // fields that are nullable are not present in the HalDoc
+    // the Flight model needs to have these fields in order to set up the flight form that is re-used between flights
+    totalGoal: flight.hasOwnProperty('totalGoal') ? flight.totalGoal : null,
+    dailyMinimum: flight.hasOwnProperty('dailyMinimum') ? flight.dailyMinimum : null,
+    contractGoal: flight.hasOwnProperty('contractGoal') ? flight.contractGoal : null
   };
   return flight;
 };

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -42,6 +42,24 @@ describe('Flight Reducer', () => {
     expect(result.entities[flightFixture.id].localFlight).toMatchObject(flightFixture);
   });
 
+  it('should ensure nullable fields are on model', () => {
+    const { totalGoal, dailyMinimum, contractGoal, contractEndAt, contractEndAtFudged, contractStartAt, ...flight } = flightDocFixture;
+    const result = reducer(
+      initialState,
+      campaignActions.CampaignLoadSuccess({
+        campaignDoc: new MockHalDoc(campaignDocFixture),
+        flightDocs: [new MockHalDoc(flight)],
+        flightDaysDocs: { [flightDocFixture.id]: flightDaysDocFixture }
+      })
+    );
+    expect(result.entities[flightFixture.id].localFlight.totalGoal).toBeNull();
+    expect(result.entities[flightFixture.id].localFlight.dailyMinimum).toBeNull();
+    expect(result.entities[flightFixture.id].localFlight.contractGoal).toBeNull();
+    expect(result.entities[flightFixture.id].localFlight.contractEndAt).toBeNull();
+    expect(result.entities[flightFixture.id].localFlight.contractEndAtFudged).toBeNull();
+    expect(result.entities[flightFixture.id].localFlight.contractStartAt).toBeNull();
+  });
+
   it('should create a new flight', () => {
     const result = reducer(initialState, campaignActions.CampaignAddFlight({ campaignId: campaignFixture.id }));
     const newFlightState = selectAll(result).find(flight => !flight.remoteFlight);

--- a/src/app/campaign/store/selectors/campaign-flight.selectors.ts
+++ b/src/app/campaign/store/selectors/campaign-flight.selectors.ts
@@ -58,7 +58,7 @@ export const selectError = createSelector(
   selectCampaignError,
   selectFlightNotFoundError,
   (campaignError: any, flightNotFoundError: string) => {
-    return (campaignError && campaignError.body && campaignError.body.message) || flightNotFoundError;
+    return campaignError && campaignError.body && campaignError.body.message;
   }
 );
 


### PR DESCRIPTION
* closes #233 ensures nullable fields on flight are set in order to support form re-use
* closes #228 
  * adds an emitGuard to form array components for wrapping incoming updates
  * adds a filter to the flight form update stream to check that form flight and routed flight ids match
* uses an errorStateMatcher with the zones url (wasn't showing up as invalid)
* ensures that the creative url is cleared for empty zones
* uses onlySelf in ControlValueAccessor to update self but not parent
* removes the Flight Not Found error that started popping up frequently when the check for form save errors moved into the error service with the dismissible snackbar. This error intention was for an invalid flight id route, giving a lot of false positives, so maybe we can readdress at some point.
