### PR TITLE
fixes creative url carryover

### DIFF
--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -65,7 +65,8 @@ export const docToFlight = (doc: HalDoc): Flight => {
     // the Flight model needs to have these fields in order to set up the flight form that is re-used between flights
     totalGoal: flight.hasOwnProperty('totalGoal') ? flight.totalGoal : null,
     dailyMinimum: flight.hasOwnProperty('dailyMinimum') ? flight.dailyMinimum : null,
-    contractGoal: flight.hasOwnProperty('contractGoal') ? flight.contractGoal : null
+    contractGoal: flight.hasOwnProperty('contractGoal') ? flight.contractGoal : null,
+    zones: flight.zones.map(({ id, label, url, fileSize, mimeType }) => ({ id, label, url, fileSize, mimeType }))
   };
   return flight;
 };

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -58,6 +58,7 @@ describe('Flight Reducer', () => {
     expect(result.entities[flightFixture.id].localFlight.contractEndAt).toBeNull();
     expect(result.entities[flightFixture.id].localFlight.contractEndAtFudged).toBeNull();
     expect(result.entities[flightFixture.id].localFlight.contractStartAt).toBeNull();
+    expect(result.entities[flightFixture.id].localFlight.zones[0].hasOwnProperty('url')).toBeTruthy();
   });
 
   it('should create a new flight', () => {


### PR DESCRIPTION
closes #243 

Navigate between tabs on a campaign with multiple flights where some zones have creative urls and some don't. See that the creative urls stay with their own flight and don't get copied into new or other flights when navigating.