### PR TITLE
Rename allocation status

### DIFF
--- a/src/app/campaign/inventory/inventory.component.spec.ts
+++ b/src/app/campaign/inventory/inventory.component.spec.ts
@@ -122,9 +122,9 @@ describe('InventoryComponent', () => {
   });
 
   describe('errors', () => {
-    it('has flight status messages', () => {
+    it('has flight allocation status messages', () => {
       expect(comp.errors).toEqual([]);
-      comp.flight = { ...flightFixture, statusMessage: 'something bad' };
+      comp.flight = { ...flightFixture, allocationStatusMessage: 'something bad' };
       expect(comp.errors).toEqual(['something bad']);
     });
 

--- a/src/app/campaign/inventory/inventory.component.ts
+++ b/src/app/campaign/inventory/inventory.component.ts
@@ -40,7 +40,7 @@ export class InventoryComponent {
   zoneWeekExpanded = {};
 
   get errors() {
-    return [this.decodedPreviewError, this.flight.statusMessage].filter(error => !!error);
+    return [this.decodedPreviewError, this.flight.allocationStatusMessage].filter(error => !!error);
   }
 
   // TODO: Updated with discussed "nice_message" when available.

--- a/src/app/campaign/nav/campaign-nav.component.ts
+++ b/src/app/campaign/nav/campaign-nav.component.ts
@@ -15,10 +15,10 @@ import { Campaign, FlightState } from '../store/models';
         [class.changed]="flight.changed"
         [class.valid]="flight.valid"
         [class.invalid]="!flight.valid"
-        [class.error]="!statusOk(flight)"
+        [class.error]="!allocationStatusOk(flight)"
       >
         <span matLine>{{ flight.localFlight?.name }}</span>
-        <mat-icon color="warn" *ngIf="!statusOk(flight)">priority_high</mat-icon>
+        <mat-icon color="warn" *ngIf="!allocationStatusOk(flight)">priority_high</mat-icon>
       </a>
     </mat-nav-list>
     <a class="secondary-link" routerLink="" (click)="createFlight.emit()"><mat-icon>add</mat-icon> Add a Flight</a>
@@ -34,7 +34,7 @@ export class CampaignNavComponent {
   @Input() isSaving: boolean;
   @Output() createFlight = new EventEmitter();
 
-  statusOk(flight: FlightState): boolean {
-    return !flight.localFlight.status || flight.localFlight.status === 'ok';
+  allocationStatusOk(flight: FlightState): boolean {
+    return !flight.localFlight.allocationStatus || flight.localFlight.allocationStatus === 'ok';
   }
 }

--- a/src/app/campaign/store/actions/flight-preview-action.creator.ts
+++ b/src/app/campaign/store/actions/flight-preview-action.creator.ts
@@ -15,8 +15,8 @@ export const FlightPreviewCreateSuccess = createAction(
   ActionTypes.CAMPAIGN_FLIGHT_PREVIEW_CREATE_SUCCESS,
   props<{
     flight: Flight;
-    status: string;
-    statusMessage: string;
+    allocationStatus: string;
+    allocationStatusMessage: string;
     flightDaysDocs: HalDoc[];
     flightDoc?: HalDoc;
     campaignDoc?: HalDoc;

--- a/src/app/campaign/store/effects/flight-preview.effects.spec.ts
+++ b/src/app/campaign/store/effects/flight-preview.effects.spec.ts
@@ -45,7 +45,7 @@ describe('FlightPreviewEffects', () => {
         {
           provide: FlightPreviewService,
           useValue: {
-            createFlightPreview: jest.fn(() => of({ status: 'ok', statusMessage: null, days: flightDaysDocFixture }))
+            createFlightPreview: jest.fn(() => of({ allocationStatus: 'ok', allocationStatusMessage: null, days: flightDaysDocFixture }))
           }
         },
         { provide: Actions, useFactory: getActions }
@@ -59,8 +59,8 @@ describe('FlightPreviewEffects', () => {
   it('should create flight preview', () => {
     const success = flightPreviewActions.FlightPreviewCreateSuccess({
       flight: flightFixture,
-      status: 'ok',
-      statusMessage: null,
+      allocationStatus: 'ok',
+      allocationStatusMessage: null,
       flightDaysDocs: flightDaysDocFixture,
       flightDoc,
       campaignDoc

--- a/src/app/campaign/store/effects/flight-preview.effects.ts
+++ b/src/app/campaign/store/effects/flight-preview.effects.ts
@@ -13,11 +13,11 @@ export class FlightPreviewEffects {
       switchMap(action => {
         const { flight, flightDoc, campaignDoc } = action;
         return this.flightPreviewService.createFlightPreview(flight, flightDoc, campaignDoc).pipe(
-          map(({ status, statusMessage, days: flightDaysDocs }) => {
+          map(({ allocationStatus, allocationStatusMessage, days: flightDaysDocs }) => {
             return flightPreviewActions.FlightPreviewCreateSuccess({
               flight,
-              status,
-              statusMessage,
+              allocationStatus,
+              allocationStatusMessage,
               flightDaysDocs,
               flightDoc,
               campaignDoc

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -30,8 +30,8 @@ export interface Flight {
   actualCount?: number;
   dailyMinimum?: number;
   deliveryMode: string;
-  status?: string;
-  statusMessage?: string;
+  allocationStatus?: string;
+  allocationStatusMessage?: string;
   createdAt?: Date;
   contractGoal?: number;
   contractStartAt?: Moment;

--- a/src/app/campaign/store/reducers/flight-days.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight-days.reducer.spec.ts
@@ -112,8 +112,8 @@ describe('Flight Days/Preview Reducer', () => {
       result,
       flightPreviewActions.FlightPreviewCreateSuccess({
         flight: flightDocFixture,
-        status: 'ok',
-        statusMessage: null,
+        allocationStatus: 'ok',
+        allocationStatusMessage: null,
         flightDaysDocs: flightDaysDocFixture,
         flightDoc: new MockHalDoc(flightDocFixture),
         campaignDoc: new MockHalDoc(campaignDocFixture)

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -289,7 +289,7 @@ describe('Flight Reducer', () => {
     expect(state.entities[timestamp].localFlight.createdAt).toBeUndefined();
   });
 
-  it('should update the flight status/message from preview', () => {
+  it('should update the flight allocation status/message from preview', () => {
     let result = reducer(
       initialState,
       campaignActions.CampaignLoadSuccess({
@@ -302,13 +302,13 @@ describe('Flight Reducer', () => {
       result,
       flightPreviewActions.FlightPreviewCreateSuccess({
         flight: flightFixture,
-        status: 'error',
-        statusMessage: 'something bad',
+        allocationStatus: 'error',
+        allocationStatusMessage: 'something bad',
         flightDaysDocs: []
       })
     );
     expect(result.entities[flightFixture.id].localFlight).toMatchObject(flightFixture);
-    expect(result.entities[flightFixture.id].localFlight.status).toBe('error');
-    expect(result.entities[flightFixture.id].localFlight.statusMessage).toBe('something bad');
+    expect(result.entities[flightFixture.id].localFlight.allocationStatus).toBe('error');
+    expect(result.entities[flightFixture.id].localFlight.allocationStatusMessage).toBe('something bad');
   });
 });

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -130,9 +130,12 @@ const _reducer = createReducer(
     return newState;
   }),
   on(flightPreviewActions.FlightPreviewCreateSuccess, (state, action) => {
-    const { flight, status, statusMessage } = action;
+    const { flight, allocationStatus, allocationStatusMessage } = action;
     const localFlight = state.entities[flight.id].localFlight;
-    return adapter.updateOne({ id: flight.id, changes: { localFlight: { ...localFlight, status, statusMessage } } }, state);
+    return adapter.updateOne(
+      { id: flight.id, changes: { localFlight: { ...localFlight, allocationStatus, allocationStatusMessage } } },
+      state
+    );
   })
 );
 

--- a/src/app/core/campaign/flight-preview.service.ts
+++ b/src/app/core/campaign/flight-preview.service.ts
@@ -12,7 +12,7 @@ export class FlightPreviewService {
     flight: {},
     flightDoc?: HalDoc,
     campaignDoc?: HalDoc
-  ): Observable<{ status: string; statusMessage: string; days: HalDoc[] }> {
+  ): Observable<{ allocationStatus: string; allocationStatusMessage: string; days: HalDoc[] }> {
     if (flightDoc) {
       return this.preview(flight, flightDoc, 'preview');
     } else if (campaignDoc) {
@@ -29,8 +29,8 @@ export class FlightPreviewService {
     return doc.create(link, {}, flight).pipe(
       mergeMap((flightPreviewDoc: HalDoc) => {
         return forkJoin({
-          status: of(flightPreviewDoc['status']),
-          statusMessage: of(flightPreviewDoc['statusMessage']),
+          allocationStatus: of(flightPreviewDoc['allocationStatus']),
+          allocationStatusMessage: of(flightPreviewDoc['allocationStatusMessage']),
           days: flightPreviewDoc.followList('prx:flight-days')
         });
       })

--- a/src/app/dashboard/dashboard.service.mock.ts
+++ b/src/app/dashboard/dashboard.service.mock.ts
@@ -8,8 +8,8 @@ export const flights: Flight[] = [
   {
     id: 1,
     name: 'Flight 1',
-    status: 'ok',
-    statusOk: true,
+    allocationStatus: 'ok',
+    allocationStatusOk: true,
     startAt: new Date('2019-09-01 0:0:0'),
     endAt: new Date('2019-09-10 0:0:0'),
     totalGoal: 1234,
@@ -28,8 +28,8 @@ export const flights: Flight[] = [
   {
     id: 2,
     name: 'Flight 2',
-    status: 'error',
-    statusOk: false,
+    allocationStatus: 'error',
+    allocationStatusOk: false,
     startAt: new Date('2019-09-02 0:0:0'),
     endAt: new Date('2019-09-13 0:0:0'),
     totalGoal: 54321,

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -58,8 +58,8 @@ export interface Facets {
 export interface Flight {
   id: number;
   name: string;
-  status: string;
-  statusOk: boolean;
+  allocationStatus: string;
+  allocationStatusOk: boolean;
   startAt: Date;
   endAt: Date;
   zones: string[];
@@ -237,8 +237,8 @@ export class DashboardService {
             flights: flightDocs.map(doc => ({
               id: doc['id'],
               name: doc['name'],
-              status: doc['status'],
-              statusOk: doc['status'] === 'ok',
+              allocationStatus: doc['allocationStatus'],
+              allocationStatusOk: doc['allocationStatus'] === 'ok',
               startAt: doc['startAt'] && new Date(doc['startAt']),
               endAt:
                 doc['endAt'] &&
@@ -296,8 +296,8 @@ export class DashboardService {
           const flight: Flight = {
             id: flightDoc['id'],
             name: flightDoc['name'],
-            status: flightDoc['status'],
-            statusOk: flightDoc['status'] === 'ok',
+            allocationStatus: flightDoc['allocationStatus'],
+            allocationStatusOk: flightDoc['allocationStatus'] === 'ok',
             startAt: flightDoc['startAt'] && new Date(flightDoc['startAt']),
             endAt:
               flightDoc['endAt'] &&

--- a/src/app/dashboard/flight-table/flight-table.component.html
+++ b/src/app/dashboard/flight-table/flight-table.component.html
@@ -11,7 +11,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
         Flight Name
       </th>
-      <td mat-cell *matCellDef="let element" [class.error]="!element.statusOk">
+      <td mat-cell *matCellDef="let element" [class.error]="!element.allocationStatusOk">
         <a [routerLink]="['/campaign', element?.parent?.id, 'flight', element?.id]">{{ element.name }}</a>
       </td>
       <td mat-footer-cell *matFooterCellDef>
@@ -35,12 +35,12 @@
       <td mat-footer-cell *matFooterCellDef>{{ totalGoals | largeNumber }}</td>
     </ng-container>
 
-    <ng-container matColumnDef="status" cssClassFriendlyName>
+    <ng-container matColumnDef="allocation_status" cssClassFriendlyName>
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
-        F. Status
+        Allocations
       </th>
       <td mat-cell *matCellDef="let element">
-        <span class="status {{ element.status }}">{{ element.status | titlecase }}</span>
+        <span class="status {{ element.allocationStatus }}">{{ element.allocationStatus | titlecase }}</span>
       </td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
@@ -103,7 +103,7 @@
 
     <ng-container matColumnDef="campaign_status" cssClassFriendlyName>
       <th mat-header-cell *matHeaderCellDef mat-sort-header>
-        C. Status
+        Status
       </th>
       <td mat-cell *matCellDef="let element">
         <span class="status {{ element?.parent?.status }}">{{ element?.parent?.status | titlecase }}</span>

--- a/src/app/dashboard/flight-table/flight-table.component.ts
+++ b/src/app/dashboard/flight-table/flight-table.component.ts
@@ -20,7 +20,7 @@ export class FlightTableComponent implements AfterViewInit, OnInit, OnDestroy {
   displayedColumns: string[] = [
     'name',
     'campaign_status',
-    'status',
+    'allocation_status',
     'campaign_name',
     'start_at',
     'end_at',


### PR DESCRIPTION
Closes PRX/augury.prx.org#301.

Renames flight `status` and `statusMessage` to `allocationStatus` and `allocationStatusMessage`.  In prep for moving the current campaign-status field to flight-status.

Must deploy concurrently with PRX/augury/.prx.org#321.