### PR TITLE
Fixes duplication issues

### DIFF
--- a/src/app/campaign/store/effects/campaign.effects.ts
+++ b/src/app/campaign/store/effects/campaign.effects.ts
@@ -259,8 +259,15 @@ export class CampaignEffects {
             campaign,
             flights: flights.map(flight => ({
               ...flight,
+              // TWO THINGS:
+              // * Clear all flight dates on duplication
+              // * Moments cannot be serialized into state on the router, so the dates error unless translated to a string type or whatever
               startAt: undefined,
-              endAt: undefined
+              endAt: undefined,
+              endAtFudged: undefined,
+              contractStartAt: undefined,
+              contractEndAt: undefined,
+              contractEndAtFudged: undefined
             }))
           };
           this.router.navigate(['/campaign', 'new'], { state });

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -74,15 +74,24 @@ export const docToFlight = (doc: HalDoc): Flight => {
 };
 
 export const duplicateFlightState = (flight: Flight, tempId: number, changed: boolean, valid: boolean): FlightState => {
-  // remove createdAt, startAt, endAt, and set temp id
-  const { createdAt, startAt, endAt, name, ...dupFlight } = flight;
+  // remove createdAt
+  const { createdAt, name, ...dupFlight } = flight;
 
   return {
     localFlight: {
       ...dupFlight,
+      // set the temp id
       id: tempId,
       name: `Copy of ${name}`,
-      status: 'draft'
+      // duplicated status becomes Draft
+      status: 'draft',
+      // clear all flight dates (dates must be present on flight model to reset form controls from the duplicated flight)
+      startAt: undefined,
+      endAt: undefined,
+      endAtFudged: undefined,
+      contractStartAt: undefined,
+      contractEndAt: undefined,
+      contractEndAtFudged: undefined
     } as Flight,
     changed,
     valid

--- a/src/app/campaign/store/reducers/flight.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.spec.ts
@@ -106,7 +106,7 @@ describe('Flight Reducer', () => {
       initialState,
       campaignActions.CampaignDupFlight({ campaignId: campaignFixture.id, flightId: Date.now(), flight: flightFixture })
     );
-    const dupFlight = selectAll(result).find(flight => flight.localFlight.name.indexOf('(Copy)') > -1);
+    const dupFlight = selectAll(result).find(flight => flight.localFlight.name.indexOf('Copy of') > -1);
     expect(dupFlight.localFlight.zones).toBe(flightFixture.zones);
   });
 

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -68,7 +68,7 @@ const _reducer = createReducer(
   }),
   on(campaignActions.CampaignDupFlight, (state, action) => {
     const { flight, flightId } = action;
-    return adapter.addOne(duplicateFlightState({ ...flight, name: `${flight.name} (Copy)` }, flightId, true, true), state);
+    return adapter.addOne(duplicateFlightState({ ...flight, name: `${flight.name}` }, flightId, true, true), state);
   }),
   on(campaignActions.CampaignDeleteFlight, (state, action) => {
     const { id, softDeleted } = action;


### PR DESCRIPTION
Two for one!
* closes #254 resolves the campaign duplication error by removing Moment flight dates that don't serialize on router state
* closes #255 clears _all_ flight dates on duplication