### PR TITLE
Flight status transitions

### DIFF
--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -3,13 +3,13 @@ import { AbstractControl, FormBuilder, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import {
   Flight,
-  FlightZone,
   InventoryRollup,
   Inventory,
   InventoryZone,
   InventoryTargets,
   InventoryTargetType,
-  InventoryTargetsMap
+  InventoryTargetsMap,
+  FlightStatusOption
 } from '../store/models';
 import { utc } from 'moment';
 
@@ -22,6 +22,7 @@ import { utc } from 'moment';
         [zoneOptions]="zoneOptions"
         [targetTypes]="targetTypes"
         [targetOptionsMap]="targetOptionsMap"
+        [statusOptions]="statusOptions"
         [flight]="flight"
         [softDeleted]="softDeleted"
         (flightDeleteToggle)="flightDeleteToggle.emit($event)"
@@ -47,6 +48,7 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
   @Input() targetOptions: InventoryTargets;
   @Input() targetTypes: InventoryTargetType[];
   @Input() targetOptionsMap: InventoryTargetsMap;
+  @Input() statusOptions: FlightStatusOption[];
   @Input() rollup: InventoryRollup;
   @Input() isPreview: boolean;
   @Input() isLoading: boolean;

--- a/src/app/campaign/flight/flight-form.component.ts
+++ b/src/app/campaign/flight/flight-form.component.ts
@@ -1,16 +1,7 @@
 import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { FormGroup, AbstractControl, ControlContainer } from '@angular/forms';
 import { ErrorStateMatcher } from '@angular/material';
-import {
-  Flight,
-  FlightZone,
-  Inventory,
-  InventoryZone,
-  InventoryTargets,
-  InventoryTargetType,
-  FlightTarget,
-  InventoryTargetsMap
-} from '../store/models';
+import { Flight, Inventory, InventoryZone, InventoryTargetType, InventoryTargetsMap, FlightStatusOption } from '../store/models';
 
 export class FlightFormErrorStateMatcher implements ErrorStateMatcher {
   isErrorState(control: AbstractControl): boolean {
@@ -29,23 +20,13 @@ export class FlightFormComponent implements OnInit {
   @Input() zoneOptions: InventoryZone[];
   @Input() targetTypes: InventoryTargetType[];
   @Input() targetOptionsMap: InventoryTargetsMap;
+  @Input() statusOptions: FlightStatusOption[];
   @Input() softDeleted: boolean;
   @Output() flightDuplicate = new EventEmitter<Flight>(true);
   @Output() flightDeleteToggle = new EventEmitter(true);
 
   flightForm: FormGroup;
   matcher = new FlightFormErrorStateMatcher();
-
-  readonly statusOptions = [
-    { name: 'Draft', value: 'draft' },
-    { name: 'Hold', value: 'hold' },
-    { name: 'Sold', value: 'sold' },
-    { name: 'Approved', value: 'approved' },
-    { name: 'Paused', value: 'paused' },
-    { name: 'Canceled', value: 'canceled' },
-    { name: 'Completed', value: 'completed' },
-    { name: 'Unfulfilled', value: 'unfulfilled' }
-  ];
 
   ngOnInit() {
     this.flightForm = this.formContainer.control as FormGroup;

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -4,7 +4,15 @@ import { Store, select } from '@ngrx/store';
 import { Observable, Subscription, combineLatest } from 'rxjs';
 import { filter, withLatestFrom } from 'rxjs/operators';
 import { MatDrawer } from '@angular/material/sidenav';
-import { Flight, InventoryRollup, Inventory, InventoryZone, InventoryTargetType, InventoryTargetsMap } from '../store/models';
+import {
+  Flight,
+  InventoryRollup,
+  Inventory,
+  InventoryZone,
+  InventoryTargetType,
+  InventoryTargetsMap,
+  FlightStatusOption
+} from '../store/models';
 import {
   selectRoutedLocalFlight,
   selectRoutedFlightDeleted,
@@ -19,6 +27,7 @@ import {
   selectCurrentInventoryZones,
   selectCurrentInventoryTargetTypes,
   selectCurrentInventoryTargetsTypeMap,
+  selectCurrentStatusOptions,
   selectFlightActualsDateBoundaries,
   selectCampaignId,
   selectShowCreativeListRoute
@@ -35,6 +44,7 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
           [zoneOptions]="zoneOptions$ | async"
           [targetTypes]="targetTypes$ | async"
           [targetOptionsMap]="targetOptionsMap$ | async"
+          [statusOptions]="statusOptions$ | async"
           [flight]="flightLocal$ | async"
           [softDeleted]="softDeleted$ | async"
           [rollup]="inventoryRollup$ | async"
@@ -65,6 +75,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
   zoneOptions$: Observable<InventoryZone[]>;
   targetTypes$: Observable<InventoryTargetType[]>;
   targetOptionsMap$: Observable<InventoryTargetsMap>;
+  statusOptions$: Observable<FlightStatusOption[]>;
   flightActualsDateBoundaries$: Observable<{ startAt: Date; endAt: Date }>;
   campaignId$: Observable<string | number>;
   @ViewChild('creative', { static: true }) creativeMatDrawer: MatDrawer;
@@ -86,6 +97,7 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
     this.zoneOptions$ = this.store.pipe(select(selectCurrentInventoryZones));
     this.targetTypes$ = this.store.pipe(select(selectCurrentInventoryTargetTypes));
     this.targetOptionsMap$ = this.store.pipe(select(selectCurrentInventoryTargetsTypeMap));
+    this.statusOptions$ = this.store.pipe(select(selectCurrentStatusOptions));
     this.flightActualsDateBoundaries$ = this.store.pipe(select(selectFlightActualsDateBoundaries));
     this.campaignId$ = this.store.pipe(select(selectCampaignId));
 

--- a/src/app/campaign/store/models/flight-status.models.spec.ts
+++ b/src/app/campaign/store/models/flight-status.models.spec.ts
@@ -1,0 +1,30 @@
+import { flightStatusOptions } from './flight-status.models';
+
+describe('FlightStatusModels', () => {
+  it('returns valid status options', () => {
+    const opts = flightStatusOptions('approved');
+    expect(opts.length).toEqual(3);
+    expect(opts).toContainEqual({ name: 'Approved', value: 'approved' });
+    expect(opts).toContainEqual({ name: 'Paused', value: 'paused' });
+    expect(opts).toContainEqual({ name: 'Canceled', value: 'canceled' });
+  });
+
+  it('returns default status options', () => {
+    const opts = flightStatusOptions(null);
+    expect(opts.length).toEqual(4);
+    expect(opts).toContainEqual({ name: 'Draft', value: 'draft' });
+    expect(opts).toContainEqual({ name: 'Hold', value: 'hold' });
+    expect(opts).toContainEqual({ name: 'Sold', value: 'sold' });
+    expect(opts).toContainEqual({ name: 'Approved', value: 'approved' });
+  });
+
+  it('always returns the option you pass in', () => {
+    const opts1 = flightStatusOptions('canceled');
+    expect(opts1.length).toEqual(1);
+    expect(opts1).toContainEqual({ name: 'Canceled', value: 'canceled' });
+
+    const opts2 = flightStatusOptions('anything');
+    expect(opts2.length).toEqual(1);
+    expect(opts2).toContainEqual({ name: 'Anything', value: 'anything' });
+  });
+});

--- a/src/app/campaign/store/models/flight-status.models.ts
+++ b/src/app/campaign/store/models/flight-status.models.ts
@@ -1,0 +1,23 @@
+export interface FlightStatusOption {
+  name: string;
+  value: string;
+}
+
+export const flightStatusTransitions = {
+  draft: ['hold', 'sold', 'approved'],
+  hold: ['draft', 'sold', 'approved'],
+  sold: ['draft', 'hold', 'approved'],
+  approved: ['paused', 'canceled'],
+  paused: ['approved', 'canceled'],
+  completed: ['approved'],
+  unfulfilled: ['approved']
+};
+
+export const flightStatusOptions = (status: string): FlightStatusOption[] => {
+  if (status) {
+    const allowed = [status].concat(flightStatusTransitions[status] || []);
+    return allowed.map(value => ({ name: value.charAt(0).toUpperCase() + value.slice(1), value }));
+  } else {
+    return flightStatusOptions('draft');
+  }
+};

--- a/src/app/campaign/store/models/index.ts
+++ b/src/app/campaign/store/models/index.ts
@@ -5,4 +5,5 @@ export * from './campaign-flight.models';
 export * from './creative.models';
 export * from './flight.models';
 export * from './flight-days.models';
+export * from './flight-status.models';
 export * from './inventory.models';

--- a/src/app/campaign/store/selectors/flight.selectors.spec.ts
+++ b/src/app/campaign/store/selectors/flight.selectors.spec.ts
@@ -35,6 +35,20 @@ describe('Flight Selectors', () => {
     expect(uri).toEqual(campaignStateFactory.flightFixture.set_inventory_uri);
   });
 
+  it('should select current/routed remote flight status options', () => {
+    const flightState = campaignStateFactory.createFlightsState(new MockHalDoc(campaignStateFactory.campaignDocFixture)).flights.entities[
+      campaignStateFactory.flightFixture.id
+    ];
+
+    expect(flightState.remoteFlight.status).toEqual('hold');
+    const opts = flightSelectors.selectCurrentStatusOptions.projector(flightState);
+    expect(opts.map(o => o.value)).toEqual(['hold', 'draft', 'sold', 'approved']);
+
+    const flightState2 = { ...flightState, localFlight: { ...flightState.localFlight, status: 'approved' } };
+    const opts2 = flightSelectors.selectCurrentStatusOptions.projector(flightState2);
+    expect(opts2.map(o => o.value)).toEqual(['hold', 'draft', 'sold', 'approved']);
+  });
+
   it('should select routed flight deleted', () => {
     const flightState = campaignStateFactory.createFlightsState(new MockHalDoc(campaignStateFactory.campaignDocFixture)).flights.entities[
       campaignStateFactory.flightFixture.id

--- a/src/app/campaign/store/selectors/flight.selectors.ts
+++ b/src/app/campaign/store/selectors/flight.selectors.ts
@@ -4,7 +4,7 @@ import { CampaignStoreState } from '../';
 import { selectCampaignStoreState } from './campaign.selectors';
 import { selectCreativeEntities } from './creative.selectors';
 import { selectRouterStateParams } from '../../../store/router-store/router.selectors';
-import { Flight, FlightState, CreativeState } from '../models';
+import { Flight, FlightState, CreativeState, FlightStatusOption, flightStatusOptions } from '../models';
 import { selectIds, selectEntities, selectAll } from '../reducers/flight.reducer';
 import { HalDoc } from 'ngx-prx-styleguide';
 
@@ -57,6 +57,9 @@ export const selectRoutedLocalFlightZones = createSelector(
 export const selectCurrentInventoryUri = createSelector(
   selectRoutedLocalFlight,
   (flight: Flight): string => flight && flight.set_inventory_uri
+);
+export const selectCurrentStatusOptions = createSelector(selectRoutedFlight, (flightState: FlightState): FlightStatusOption[] =>
+  flightStatusOptions(flightState && flightState.remoteFlight && flightState.remoteFlight.status)
 );
 export const selectRoutedFlightDeleted = createSelector(
   selectRoutedFlight,

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -238,7 +238,7 @@ export class DashboardService {
               name: doc['name'],
               status: doc['status'],
               allocationStatus: doc['allocationStatus'],
-              allocationStatusOk: doc['allocationStatus'] === 'ok',
+              allocationStatusOk: doc['allocationStatus'] === 'ok' && doc['status'] !== 'canceled',
               startAt: doc['startAt'] && new Date(doc['startAt']),
               endAt:
                 doc['endAt'] &&
@@ -298,7 +298,7 @@ export class DashboardService {
             name: flightDoc['name'],
             status: flightDoc['status'],
             allocationStatus: flightDoc['allocationStatus'],
-            allocationStatusOk: flightDoc['allocationStatus'] === 'ok',
+            allocationStatusOk: flightDoc['allocationStatus'] === 'ok' || flightDoc['status'] === 'canceled',
             startAt: flightDoc['startAt'] && new Date(flightDoc['startAt']),
             endAt:
               flightDoc['endAt'] &&

--- a/src/sass/_status.scss
+++ b/src/sass/_status.scss
@@ -15,9 +15,13 @@
   background-color: mat-color($prx-yellow-palette, default);
 }
 .error,
-.canceled {
+.unfulfilled {
   color: mat-color($prx-red-palette, default-contrast);
   background-color: mat-color($prx-red-palette, default);
+}
+.completed {
+  color: mat-color($prx-blue-palette, default-contrast);
+  background-color: mat-color($prx-blue-palette, default);
 }
 .hold {
   color: mat-color($prx-orange-palette, default-contrast);


### PR DESCRIPTION
Closes #247.

The flight-status dropdown will now only contain options you're allowed to transition to from the current `flightState.remoteFlight.status`.  So you have to successfully save your flight to see the options change.

![image](https://user-images.githubusercontent.com/1410587/94847100-5b57c080-03df-11eb-830d-81a30f934cac.png)

(Also tweaked some flight-dashboard status colors a bit, to ignore `canceled` and include `unfullfilled` / `completed`).