### PR TITLE
Creative styles/validations

### DIFF
--- a/src/app/campaign/creative/creative-card.component.scss
+++ b/src/app/campaign/creative/creative-card.component.scss
@@ -33,6 +33,14 @@ h3 {
   margin: 5px 0;
 }
 
+.weight {
+  .suffix {
+    top: -0.25em;
+    padding-left: 0.25em;
+    position: relative;
+  }
+}
+
 mat-form-field {
   margin-top: 5px;
 }

--- a/src/app/campaign/creative/creative-card.component.scss
+++ b/src/app/campaign/creative/creative-card.component.scss
@@ -4,6 +4,7 @@
   border: 1px solid prx-theme-foreground(divider);
   border-radius: 5px;
   padding: 10px;
+  background: white;
 
   ::ng-deep {
     .mat-form-field-infix {

--- a/src/app/campaign/creative/creative-card.component.scss
+++ b/src/app/campaign/creative/creative-card.component.scss
@@ -5,6 +5,8 @@
   border-radius: 5px;
   padding: 10px;
   background: white;
+  display: flex;
+  flex-direction: column;
 
   ::ng-deep {
     .mat-form-field-infix {
@@ -33,7 +35,15 @@ h3 {
   margin: 5px 0;
 }
 
+.form {
+  flex: 1;
+}
+
 .weight {
+  text-align: right;
+  input {
+    direction: rtl;
+  }
   .suffix {
     top: -0.25em;
     padding-left: 0.25em;
@@ -43,4 +53,21 @@ h3 {
 
 mat-form-field {
   margin-top: 5px;
+}
+
+.remove {
+  text-align: center;
+  margin: 0 -10px -10px;
+  button {
+    display: block;
+    width: 100%;
+    border-radius: 0;
+    color: mat-color($prx-gray, 300);
+    border-top: 1px solid mat-color($prx-gray, 300);
+    &:hover,
+    &:focus {
+      color: $warn;
+      border-color: $warn;
+    }
+  }
 }

--- a/src/app/campaign/creative/creative-card.component.spec.ts
+++ b/src/app/campaign/creative/creative-card.component.spec.ts
@@ -7,6 +7,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatIconModule } from '@angular/material/icon';
 import { SharedModule } from '../../shared/shared.module';
 import { CreativeCardComponent } from './creative-card.component';
 @Component({
@@ -28,7 +29,7 @@ class ParentFormComponent {
     set_account_uri: '/api/v1/accounts/1',
     set_advertiser_uri: '/some/uri/1'
   };
-  creativeLink = '/campaign/1/flight/2/zone/pre_1/creative/1';
+  creativeLink = '/campaign/1/flight/2/zone/pre_1/creative/';
 
   form = this.fb.group({
     enabled: [true],
@@ -51,7 +52,8 @@ describe('CreativeCardComponent', () => {
         ReactiveFormsModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSlideToggleModule
+        MatSlideToggleModule,
+        MatIconModule
       ],
       declarations: [ParentFormComponent, CreativeCardComponent]
     })
@@ -65,9 +67,9 @@ describe('CreativeCardComponent', () => {
       });
   }));
 
-  it('shows link to creative if one is provided', () => {
+  it('shows link to creative if it exists', () => {
     expect(de.query(By.css('a')).nativeElement.textContent).toContain(parent.creative.filename);
-    parent.creativeLink = '';
+    parent.creative.id = null;
     fix.detectChanges();
     expect(de.query(By.css('a'))).toBeNull();
   });

--- a/src/app/campaign/creative/creative-card.component.ts
+++ b/src/app/campaign/creative/creative-card.component.ts
@@ -1,23 +1,28 @@
-import { Component, Input, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, ChangeDetectionStrategy, Output, EventEmitter } from '@angular/core';
 import { FormGroup, ControlContainer } from '@angular/forms';
 import { Creative } from '../store/models';
 
 @Component({
   selector: 'grove-creative-card',
   template: `
-    <div [formGroup]="creativeForm">
+    <div [formGroup]="creativeForm" class="form">
       <h3>
         {{ creative?.id ? 'Creative' : 'Silent File' }}
         <mat-slide-toggle formControlName="enabled" aria-label="disable"></mat-slide-toggle>
       </h3>
-      <a *ngIf="creativeLink" class="creative" [routerLink]="creativeLink" [class.disabled]="isDisabled()">
+      <a *ngIf="creative?.id" class="creative" [routerLink]="creativeLink + creative.id" [class.disabled]="isDisabled()">
         {{ creative?.filename || creative?.url }}
       </a>
-      <mat-form-field appearance="outline" class="weight">
-        <mat-label>Weight</mat-label>
-        <input type="number" required min="1" matInput formControlName="weight" />
-        <span class="suffix" matSuffix>%</span>
-      </mat-form-field>
+      <fieldset>
+        <mat-form-field appearance="outline" class="weight">
+          <mat-label>Weight</mat-label>
+          <input type="number" required min="1" matInput formControlName="weight" />
+          <span class="suffix" matSuffix>%</span>
+        </mat-form-field>
+      </fieldset>
+    </div>
+    <div *ngIf="canRemove()" class="remove">
+      <button mat-button color="warn" (click)="onRemoveCreative()"><mat-icon>close</mat-icon> Remove</button>
     </div>
   `,
   styleUrls: ['./creative-card.component.scss'],
@@ -26,6 +31,7 @@ import { Creative } from '../store/models';
 export class CreativeCardComponent implements OnInit {
   @Input() creative: Creative;
   @Input() creativeLink: string;
+  @Output() remove = new EventEmitter();
   creativeForm: FormGroup;
 
   ngOnInit() {
@@ -36,5 +42,14 @@ export class CreativeCardComponent implements OnInit {
 
   isDisabled() {
     return !this.creativeForm.get('enabled').value;
+  }
+
+  canRemove() {
+    // TODO: check if creative-flight-zone actuals > 0
+    return true;
+  }
+
+  onRemoveCreative() {
+    this.remove.emit();
   }
 }

--- a/src/app/campaign/creative/creative-card.component.ts
+++ b/src/app/campaign/creative/creative-card.component.ts
@@ -13,9 +13,10 @@ import { Creative } from '../store/models';
       <a *ngIf="creativeLink" class="creative" [routerLink]="creativeLink" [class.disabled]="isDisabled()">
         {{ creative?.filename || creative?.url }}
       </a>
-      <mat-form-field appearance="outline">
+      <mat-form-field appearance="outline" class="weight">
         <mat-label>Weight</mat-label>
         <input type="number" required min="1" matInput formControlName="weight" />
+        <span class="suffix" matSuffix>%</span>
       </mat-form-field>
     </div>
   `,

--- a/src/app/campaign/creative/creative-card.component.ts
+++ b/src/app/campaign/creative/creative-card.component.ts
@@ -13,13 +13,11 @@ import { Creative } from '../store/models';
       <a *ngIf="creative?.id" class="creative" [routerLink]="creativeLink + creative.id" [class.disabled]="isDisabled()">
         {{ creative?.filename || creative?.url }}
       </a>
-      <fieldset>
-        <mat-form-field appearance="outline" class="weight">
-          <mat-label>Weight</mat-label>
-          <input type="number" required min="1" matInput formControlName="weight" />
-          <span class="suffix" matSuffix>%</span>
-        </mat-form-field>
-      </fieldset>
+      <mat-form-field appearance="outline" class="weight">
+        <mat-label>Weight</mat-label>
+        <input type="number" required min="1" matInput formControlName="weight" />
+        <span class="suffix" matSuffix>%</span>
+      </mat-form-field>
     </div>
     <div *ngIf="canRemove()" class="remove">
       <button mat-button color="warn" (click)="onRemoveCreative()"><mat-icon>close</mat-icon> Remove</button>

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -53,15 +53,13 @@
     <div class="mat-form-field-wrapper flight-zones">
       <div class="flight-zones-header">
         <h2>Zones</h2>
-        <div *ngIf="zones.showAddZone">
-          <button mat-button color="primary" (click)="zones.onAddZone()"><mat-icon>add</mat-icon> {{ zones.addZoneLabel }}</button>
-        </div>
         <mat-slide-toggle formControlName="isCompanion">Companions</mat-slide-toggle>
       </div>
       <grove-flight-zones
         #zones
         formControlName="zones"
         [flightZones]="flight?.zones"
+        [flightStatus]="flight?.status"
         [isCompanion]="flight?.isCompanion"
         [zoneOptions]="zoneOptions"
       ></grove-flight-zones>

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -60,7 +60,7 @@
         formControlName="zones"
         [flightZones]="flight?.zones"
         [flightStatus]="flight?.status"
-        [isCompanion]="flight?.isCompanion"
+        [flightIsCompanion]="flight?.isCompanion"
         [zoneOptions]="zoneOptions"
       ></grove-flight-zones>
     </div>

--- a/src/app/campaign/flight/flight-form.component.scss
+++ b/src/app/campaign/flight/flight-form.component.scss
@@ -63,11 +63,8 @@ mat-card {
   display: flex;
   align-items: center;
 
-  h2 {
-    margin: 0 5px 0 0;
-  }
-
   mat-slide-toggle {
     margin-left: auto;
+    margin-bottom: 0.5em;
   }
 }

--- a/src/app/campaign/flight/flight-zones-form.component.html
+++ b/src/app/campaign/flight/flight-zones-form.component.html
@@ -26,10 +26,11 @@
 
       <div *ngIf="zoneHasCreatives(zone)" class="flight-zone-creatives">
         <grove-creative-card
-          *ngFor="let zoneCreative of flightZones[i]?.creativeFlightZones; let creativeIndex = index; trackBy: trackByIndex"
-          [formGroup]="creativeFormGroup(zone, creativeIndex)"
-          [creative]="creatives$[zoneCreative.creativeId] | async"
-          creativeLink="{{ zoneCreative?.creativeId ? (getZoneCreativeRoute(zone) | async) + zoneCreative.creativeId.toString() : '' }}"
+          *ngFor="let ctrl of zone.get('creativeFlightZones').controls; index as index"
+          [formGroup]="ctrl"
+          [creative]="getCreative(i, index) | async"
+          [creativeLink]="getZoneCreativeRoute(zone) | async"
+          (remove)="onRemoveCreative(zone, index)"
         ></grove-creative-card>
       </div>
     </mat-card-content>

--- a/src/app/campaign/flight/flight-zones-form.component.html
+++ b/src/app/campaign/flight/flight-zones-form.component.html
@@ -45,6 +45,9 @@
   <mat-error *ngIf="zoneError('noEnabledCreatives')">
     All zones must have at least one enabled creative.
   </mat-error>
+  <mat-error *ngIf="zoneError('mismatchedCompanionZones')">
+    The state/weight/position of companion zone creatives must all line up.
+  </mat-error>
 
   <div class="add-zone">
     <button mat-button color="primary" [matMenuTriggerFor]="addZoneMenu" [disabled]="!canAddZone">

--- a/src/app/campaign/flight/flight-zones-form.component.html
+++ b/src/app/campaign/flight/flight-zones-form.component.html
@@ -1,0 +1,56 @@
+<fieldset>
+  <mat-card *ngFor="let zone of zones?.controls; let i = index" [formGroup]="zone" class="zone">
+    <mat-card-header>
+      <mat-card-title>{{ zoneLabel(zone) }}</mat-card-title>
+
+      <div class="add-creative">
+        <button mat-button color="primary" [matMenuTriggerFor]="addCreativeMenu"><mat-icon>add</mat-icon> Add a creative</button>
+        <mat-menu #addCreativeMenu="matMenu" xPosition="after">
+          <a mat-menu-item routerLink="{{ (getZoneCreativeRoute(zone) | async) + 'new' }}">Add New</a>
+          <a mat-menu-item routerLink="{{ (getZoneCreativeRoute(zone) | async) + 'list' }}">Add Existing</a>
+          <button mat-menu-item color="primary" (click)="onAddSilentCreative(zone)">Add Silent</button>
+        </mat-menu>
+      </div>
+
+      <div class="remove-zone">
+        <button mat-icon-button aria-label="Remove zone" (click)="onRemoveZone(i)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+    </mat-card-header>
+
+    <mat-card-content>
+      <mat-form-field class="zone-id">
+        <input matInput type="text" formControlName="id" required />
+      </mat-form-field>
+
+      <div *ngIf="zoneHasCreatives(zone)" class="flight-zone-creatives">
+        <grove-creative-card
+          *ngFor="let zoneCreative of flightZones[i]?.creativeFlightZones; let creativeIndex = index; trackBy: trackByIndex"
+          [formGroup]="creativeFormGroup(zone, creativeIndex)"
+          [creative]="creatives$[zoneCreative.creativeId] | async"
+          creativeLink="{{ zoneCreative?.creativeId ? (getZoneCreativeRoute(zone) | async) + zoneCreative.creativeId.toString() : '' }}"
+        ></grove-creative-card>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-error *ngIf="validateHasZones()">
+    Must have at least one zone.
+  </mat-error>
+  <mat-error *ngIf="zoneError('noCreatives')">
+    All zones must have at least one creative.
+  </mat-error>
+  <mat-error *ngIf="zoneError('noEnabledCreatives')">
+    All zones must have at least one enabled creative.
+  </mat-error>
+
+  <div class="add-zone">
+    <button mat-button color="primary" [matMenuTriggerFor]="addZoneMenu" [disabled]="!canAddZone">
+      <mat-icon>add</mat-icon> {{ addZoneLabel }}
+    </button>
+    <mat-menu #addZoneMenu="matMenu" xPosition="after">
+      <button mat-menu-item *ngFor="let opt of zoneOptionsFiltered" (click)="onAddZone(opt)">{{ opt.label }}</button>
+    </mat-menu>
+  </div>
+</fieldset>

--- a/src/app/campaign/flight/flight-zones-form.component.scss
+++ b/src/app/campaign/flight/flight-zones-form.component.scss
@@ -1,25 +1,31 @@
 @import '~src/sass/variables';
 @import '~src/sass/colors';
 
-.inline-fields {
-  display: grid;
-  grid-template-columns: 1fr 40px;
-  grid-column-gap: 0.5rem;
-  align-items: center;
+.zone {
+  margin: 0.5em 0;
+  background-color: prx-theme-background(background);
 }
+
+.mat-card-title {
+  margin: 8px 0 8px -16px;
+}
+
+.add-creative {
+  flex: 1;
+}
+
 .remove-zone {
   button {
     color: mat-color($prx-gray, 300);
     &:hover {
       background-color: transparent;
-      color: mat-color($prx-gray, 600);
+      color: mat-color($prx-warn);
     }
   }
 }
 
-.zone + .zone {
-  border-top: 1px dashed prx-theme-foreground(divider);
-  padding-top: 20px;
+.zone-id {
+  display: none;
 }
 
 .flight-zone-creatives {
@@ -27,8 +33,4 @@
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   grid-auto-rows: 1fr;
   grid-gap: 20px;
-}
-
-.add-creative {
-  margin: 5px 0;
 }

--- a/src/app/campaign/flight/flight-zones-form.component.scss
+++ b/src/app/campaign/flight/flight-zones-form.component.scss
@@ -2,7 +2,7 @@
 @import '~src/sass/colors';
 
 .zone {
-  margin: 0.5em 0;
+  margin: 0.5em 0 1em;
   background-color: prx-theme-background(background);
 }
 

--- a/src/app/campaign/flight/flight-zones-form.component.scss
+++ b/src/app/campaign/flight/flight-zones-form.component.scss
@@ -17,7 +17,8 @@
 .remove-zone {
   button {
     color: mat-color($prx-gray, 300);
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: transparent;
       color: mat-color($prx-warn);
     }

--- a/src/app/campaign/flight/flight-zones-form.component.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.ts
@@ -180,6 +180,10 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnInit, O
     this.zones.removeAt(index);
   }
 
+  onRemoveCreative(zone: FormControl, index: number) {
+    (zone.get('creativeFlightZones') as FormArray).removeAt(index);
+  }
+
   // filters to the zone options remaining (each zone can only be selected once)
   get zoneOptionsFiltered(): InventoryZone[] {
     const flightZones = this.flightZones || [];
@@ -216,14 +220,17 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnInit, O
     return creatives && creatives.controls && !!creatives.controls.length;
   }
 
-  creativeFormGroup(zone: FormControl, index) {
+  creativeFormGroup(zone: FormControl, index: number) {
     return (zone.get('creativeFlightZones') as FormArray).controls[index];
   }
 
-  trackByIndex(index) {
-    // use a trackBy on the creative cards ngFor or else
-    // the cards are re-rendered when the weight is changed and UI loses focus as you type
-    return index;
+  getCreative(zoneIndex: number, creativeIndex: number): Observable<Creative> {
+    if (this.flightZones && this.flightZones[zoneIndex]) {
+      const creatives = this.flightZones[zoneIndex].creativeFlightZones;
+      if (creatives && creatives[creativeIndex] && creatives[creativeIndex].creativeId) {
+        return this.creatives$[creatives[creativeIndex].creativeId];
+      }
+    }
   }
 
   onAddSilentCreative(zone: FormControl) {

--- a/src/app/campaign/flight/flight-zones-form.component.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.ts
@@ -97,6 +97,7 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnInit, O
     // don't emit while manipulating FormArray with incoming update
     this.emitGuard = true;
     // get the correct number of zone fields and patchValue
+    zones = zones || [];
     while (this.zones.controls.length > zones.length) {
       this.zones.removeAt(this.zones.controls.length - 1);
       this.zones.markAsPristine();

--- a/src/app/campaign/flight/flight-zones-form.component.ts
+++ b/src/app/campaign/flight/flight-zones-form.component.ts
@@ -88,7 +88,7 @@ export class FlightZonesFormComponent implements ControlValueAccessor, OnInit, O
   buildCreativeFormGroup(zoneCreative): FormGroup {
     return new FormGroup({
       creativeId: new FormControl(zoneCreative.creative && zoneCreative.creativeId),
-      weight: new FormControl(zoneCreative.weight, [Validators.required, Validators.min(1), Validators.pattern(/^[0-9]+$/)]),
+      weight: new FormControl(zoneCreative.weight || 100, [Validators.required, Validators.min(1), Validators.pattern(/^[0-9]+$/)]),
       enabled: new FormControl(!zoneCreative.disabled)
     });
   }

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -6,7 +6,13 @@ import { Creative } from './creative.models';
 export interface FlightZone {
   id: string;
   label?: string;
-  creativeFlightZones?: { creativeId?: number | string; weight?: number; disabled?: boolean }[];
+  creativeFlightZones?: CreativeFlightZone[];
+}
+export interface CreativeFlightZone {
+  creativeId?: number | string;
+  weight?: number;
+  disabled?: boolean;
+  enabled?: boolean;
 }
 export interface FlightTarget {
   type: string;

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -49,6 +49,8 @@ export interface FlightState {
   softDeleted?: boolean;
 }
 
+export const DRAFT_STATES = ['draft', 'hold', 'sold'];
+
 export const getVelocity = (goal: number, min: number): string => {
   if (min && min >= goal) {
     return 'fastly';


### PR DESCRIPTION
Fixes most of #288.  (CreativeFlightZone actuals aren't in the API yet, so still 2 TODOs there).

Deviated _a little bit_ from the designs, to minimize vertical space usage.  But basically the same:

![image](https://user-images.githubusercontent.com/1410587/97210584-681fc800-1783-11eb-9fd4-8f46d02ba2ab.png)

Also changed the "zone name" dropdown to bring this into parity with the targets picker.  So you have to select a zone-name from the menu at the bottom.  (I think this is slightly more intuitive than being able to change the name of an existing zone).

![image](https://user-images.githubusercontent.com/1410587/97210679-8d143b00-1783-11eb-8508-21dde362f498.png)
