### PR TITLE
Patch the set_advertiser_uri field in all cases

### DIFF
--- a/src/app/campaign/form/campaign-form.component.spec.ts
+++ b/src/app/campaign/form/campaign-form.component.spec.ts
@@ -37,14 +37,14 @@ describe('CampaignFormComponent', () => {
       repName: 'my rep name',
       notes: 'my notes',
       set_account_uri: '/some/account',
-      set_advertiser_uri: '/advertiser/1'
+      set_advertiser_uri: 'http://augury/api/v1/advertiser/1'
     };
     fixture = TestBed.createComponent(CampaignFormComponent);
     component = fixture.componentInstance;
     component.advertisers = [
-      { id: 1, name: 'some ads', set_advertiser_uri: '/advertiser/1' },
-      { id: 2, name: 'more ads', set_advertiser_uri: '/advertiser/2' },
-      { id: 3, name: 'less ads', set_advertiser_uri: '/advertiser/3' }
+      { id: 1, name: 'some ads', set_advertiser_uri: 'http://augury/api/v1/advertiser/1' },
+      { id: 2, name: 'more ads', set_advertiser_uri: 'http://augury/api/v1/advertiser/2' },
+      { id: 3, name: 'less ads', set_advertiser_uri: 'http://augury/api/v1/advertiser/3' }
     ];
     fixture.detectChanges();
   });
@@ -66,7 +66,7 @@ describe('CampaignFormComponent', () => {
   it('emits advertiser when one is matched by name', done => {
     component.campaign = campaignFixture;
     component.campaignUpdate.subscribe(updates => {
-      expect(updates).toMatchObject({ campaign: { set_advertiser_uri: '/advertiser/2' } });
+      expect(updates).toMatchObject({ campaign: { set_advertiser_uri: 'http://augury/api/v1/advertiser/2' } });
       done();
     });
     component.set_advertiser_uri.setValue('more ads');
@@ -77,9 +77,9 @@ describe('CampaignFormComponent', () => {
     jest.spyOn(component.campaignForm, 'patchValue');
     component.updateCampaignForm({ set_advertiser_uri: '/any/random/value' } as Campaign);
     expect(component.campaignForm.patchValue).toHaveBeenCalledWith({}, { emitEvent: false, onlySelf: true });
-    component.updateCampaignForm({ set_advertiser_uri: '/advertiser/2' } as Campaign);
+    component.updateCampaignForm({ set_advertiser_uri: 'http://augury/api/v1/advertiser/2' } as Campaign);
     expect(component.campaignForm.patchValue).toHaveBeenCalledWith(
-      { set_advertiser_uri: '/advertiser/2' },
+      { set_advertiser_uri: 'http://augury/api/v1/advertiser/2' },
       { emitEvent: false, onlySelf: true }
     );
     component.updateCampaignForm({ set_advertiser_uri: null } as Campaign);

--- a/src/app/campaign/form/campaign-form.component.ts
+++ b/src/app/campaign/form/campaign-form.component.ts
@@ -87,8 +87,12 @@ export class CampaignFormComponent implements OnInit {
 
   updateCampaignForm(campaign: Campaign) {
     const { name, type, repName, notes, set_account_uri, set_advertiser_uri } = campaign;
-    const findAdvertiserByURI =
-      set_advertiser_uri && this.advertisers && this.advertisers.find(adv => adv.set_advertiser_uri === set_advertiser_uri);
+
+    // set_advertiser_uri might be a typeahead advertiser name instead
+    // NOTE: this fails if someone types a url as the advertiser name
+    const isAdvertiserName = set_advertiser_uri && !set_advertiser_uri.match(/^http(s)?:.+\/api\/v1\//);
+    console.log('updateCampaignForm', isAdvertiserName, set_advertiser_uri);
+
     // only set fields that are present, but allow fields to be explicitly set to null or empty string (new campaign)
     this.campaignForm.patchValue(
       {
@@ -97,8 +101,7 @@ export class CampaignFormComponent implements OnInit {
         ...(campaign.hasOwnProperty('repName') && { repName }),
         ...(campaign.hasOwnProperty('notes') && { notes }),
         ...(campaign.hasOwnProperty('set_account_uri') && { set_account_uri }),
-        ...((findAdvertiserByURI && { set_advertiser_uri: findAdvertiserByURI.set_advertiser_uri }) ||
-          (campaign.hasOwnProperty('set_advertiser_uri') && !set_advertiser_uri && { set_advertiser_uri }))
+        ...(!isAdvertiserName && { set_advertiser_uri })
       },
       { emitEvent: false, onlySelf: true }
     );

--- a/src/app/campaign/form/campaign-form.component.ts
+++ b/src/app/campaign/form/campaign-form.component.ts
@@ -91,7 +91,6 @@ export class CampaignFormComponent implements OnInit {
     // set_advertiser_uri might be a typeahead advertiser name instead
     // NOTE: this fails if someone types a url as the advertiser name
     const isAdvertiserName = set_advertiser_uri && !set_advertiser_uri.match(/^http(s)?:.+\/api\/v1\//);
-    console.log('updateCampaignForm', isAdvertiserName, set_advertiser_uri);
 
     // only set fields that are present, but allow fields to be explicitly set to null or empty string (new campaign)
     this.campaignForm.patchValue(


### PR DESCRIPTION
The advertiser dropdown/typeahead is not populating for existing campaigns.

I'm not sure I completely understand what's going on with this.  That form `patchValue` call appears to blank-out any text fields you don't include the keys for, which is sort of the opposite of what I'd expect from a patch.  Maybe that changed in the angular upgrade?

In any case ... the fix for this is to pattern match on the field.  If it looks like a typeahead "advertiser name" ... just leave it blank.  If it looks like a URI, include it.  For some reason that autocomplete component doesn't clear itself when it receives a blank update?

There are some other preexisting bugs with the invalid/changed status on this field as well.  (When you add a new advertiser, the field still looks invalid until you change something else in the form).  But maybe we'll tackle another day.  Or maybe the advertiser CRUD pages and get rid of this typeahead.