### PR TITLE
Dashboard filters

### DIFF
--- a/src/app/campaign/store/models/flight-status.models.spec.ts
+++ b/src/app/campaign/store/models/flight-status.models.spec.ts
@@ -3,10 +3,11 @@ import { flightStatusOptions } from './flight-status.models';
 describe('FlightStatusModels', () => {
   it('returns valid status options', () => {
     const opts = flightStatusOptions('approved');
-    expect(opts.length).toEqual(3);
+    expect(opts.length).toEqual(4);
     expect(opts).toContainEqual({ name: 'Approved', value: 'approved' });
     expect(opts).toContainEqual({ name: 'Paused', value: 'paused' });
     expect(opts).toContainEqual({ name: 'Canceled', value: 'canceled' });
+    expect(opts).toContainEqual({ name: 'Completed', value: 'completed' });
   });
 
   it('returns default status options', () => {

--- a/src/app/campaign/store/models/flight-status.models.ts
+++ b/src/app/campaign/store/models/flight-status.models.ts
@@ -7,10 +7,10 @@ export const flightStatusTransitions = {
   draft: ['hold', 'sold', 'approved'],
   hold: ['draft', 'sold', 'approved'],
   sold: ['draft', 'hold', 'approved'],
-  approved: ['paused', 'canceled'],
-  paused: ['approved', 'canceled'],
+  approved: ['paused', 'canceled', 'completed'],
+  paused: ['approved', 'canceled', 'completed'],
   completed: ['approved'],
-  unfulfilled: ['approved']
+  unfulfilled: ['approved', 'canceled', 'completed']
 };
 
 export const flightStatusOptions = (status: string): FlightStatusOption[] => {

--- a/src/app/dashboard/dashboard.service.spec.ts
+++ b/src/app/dashboard/dashboard.service.spec.ts
@@ -115,7 +115,7 @@ describe('DashboardService', () => {
         representative: 'Mich',
         text: 'Oscorp'
       })
-    ).toEqual('type=house,geo=US,CA,zone=mid_1,pre_1,text=Oscorp,representative=Mich');
+    ).toEqual('type=house,geo=US|CA,zone=mid_1|pre_1,text=Oscorp,representative=Mich');
     const before = new Date();
     const after = new Date();
     expect(
@@ -136,7 +136,15 @@ describe('DashboardService', () => {
         zone: ['mid_1', 'pre_1'],
         representative: 'Mich'
       })
-    ).toEqual('campaign_type=house,geo=US,CA,zone=mid_1,pre_1,campaign_representative=Mich');
+    ).toEqual('campaign_type=house,geo=US|CA,zone=mid_1|pre_1,campaign_representative=Mich');
+  });
+
+  it('should translate combined statuses', () => {
+    expect(
+      dashboardService.getFilters({
+        status: 'all-active'
+      })
+    ).toEqual('status=approved|paused|unfulfilled');
   });
 
   it('should build router params', done => {

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -85,6 +85,18 @@ export interface Campaign {
   actualCount?: number;
 }
 
+export const COMBINED_STATUS_FACETS: Facet[] = [
+  { id: 'all-active', label: 'All Active' },
+  { id: 'all-inactive', label: 'All Inactive' },
+  { id: 'all-draft', label: 'All Drafts' }
+];
+
+export const COMBINED_STATUSES = {
+  'all-active': ['approved', 'paused', 'unfulfilled'],
+  'all-inactive': ['completed', 'canceled'],
+  'all-draft': ['draft', 'hold', 'sold']
+};
+
 @Injectable({
   providedIn: 'root'
 })
@@ -100,7 +112,7 @@ export class DashboardService {
   // tslint:disable-next-line: variable-name
   private _error = new BehaviorSubject<Error>(null);
   // tslint:disable-next-line: variable-name
-  private _params = new BehaviorSubject<DashboardParams>({ page: 1, view: 'flights' });
+  private _params = new BehaviorSubject<DashboardParams>({ page: 1, view: 'flights', status: 'all-active' });
   // tslint:disable-next-line: variable-name
   private _campaigns = new BehaviorSubject<{ [id: number]: Campaign }>({});
   // tslint:disable-next-line: variable-name
@@ -273,7 +285,7 @@ export class DashboardService {
       ...params,
       per: (params && params.per) || 25,
       sort: (params && params.sort) || 'start_at',
-      direction: (params && params.direction) || 'desc'
+      direction: (params && params.direction) || 'asc'
     })
       .pipe(
         switchMap(([{ count, total, facets }, flightDocs]) => {
@@ -372,7 +384,9 @@ export class DashboardService {
     if (params.podcast) {
       filters += `${filters ? ',' : ''}podcast=${params.podcast}`;
     }
-    if (params.status) {
+    if (COMBINED_STATUSES[params.status]) {
+      filters += `${filters ? ',' : ''}status=${COMBINED_STATUSES[params.status].join('|')}`;
+    } else if (params.status) {
       filters += `${filters ? ',' : ''}status=${params.status}`;
     }
     if (params.type) {
@@ -383,10 +397,10 @@ export class DashboardService {
       }
     }
     if (params.geo && params.geo.length) {
-      filters += `${filters ? ',' : ''}geo=${params.geo.join(',')}`;
+      filters += `${filters ? ',' : ''}geo=${params.geo.join('|')}`;
     }
     if (params.zone && params.zone.length) {
-      filters += `${filters ? ',' : ''}zone=${params.zone.join(',')}`;
+      filters += `${filters ? ',' : ''}zone=${params.zone.join('|')}`;
     }
     if (params.text) {
       filters += `${filters ? ',' : ''}text=${params.text}`;

--- a/src/app/dashboard/filter/dashboard-filter.component.ts
+++ b/src/app/dashboard/filter/dashboard-filter.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
-import { DashboardService, DashboardParams, Facets } from '../dashboard.service';
+import { DashboardService, DashboardParams, Facets, COMBINED_STATUS_FACETS } from '../dashboard.service';
 
 @Component({
   selector: 'grove-dashboard-filter',
@@ -41,7 +41,7 @@ import { DashboardService, DashboardParams, Facets } from '../dashboard.service'
       </grove-filter-facet>
       <grove-filter-facet
         facetName="Status"
-        [options]="facets?.status"
+        [options]="statusFacets"
         [selectedOptions]="params?.status"
         (selectedOptionsChange)="routeToParams({ status: $event })"
       >
@@ -68,6 +68,12 @@ export class DashboardFilterComponent {
   @Input() facets: Facets;
 
   constructor(private dashboardService: DashboardService) {}
+
+  get statusFacets() {
+    if (this.facets && this.facets.status) {
+      return COMBINED_STATUS_FACETS.concat(this.facets.status);
+    }
+  }
 
   onDateChange(dates: { before?: Date; after?: Date }) {
     this.routeToParams({ ...dates });


### PR DESCRIPTION
Couple minor tweaks and bugfixes:

- [x] Fixed multi-select filters to actually work (augury expects `geo=US|CA` not `geo=US,CA`)
- [x] Change default flight-table sort to "start_at asc" instead of desc
- [x] Add some combined status filters - "All Active" / "All Inactive" / "All Draft"
- [x] Make the default status filter "all active"
- [x] You can now manually mark a flight as "completed" (from an approved/paused/unfulfilled status)

<img src="https://user-images.githubusercontent.com/1410587/101687846-52f7b380-3a28-11eb-9260-92b4cf07cf8e.png" width=400/>
