### PR TITLE
Fixup creative filtering

### DIFF
--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -100,8 +100,8 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
     status: ['', Validators.required],
     startAt: ['', { validators: [Validators.required, this.validateStartAt.bind(this)], updateOn: 'blur' }],
     endAtFudged: ['', { validators: [Validators.required, this.validateEndAt.bind(this)], updateOn: 'blur' }],
-    contractStartAt: ['', { validators: [this.validateContractStartAt.bind(this)], updateOn: 'blur' }],
-    contractEndAtFudged: ['', { validators: [this.validateContractEndAt.bind(this)], updateOn: 'blur' }],
+    contractStartAt: [''],
+    contractEndAtFudged: [''],
     isCompanion: [false],
     zones: [''],
     targets: [''],
@@ -126,14 +126,6 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
     if (this.formSubcription) {
       this.formSubcription.unsubscribe();
     }
-  }
-
-  validateContractStartAt(startAtCtrl: AbstractControl): { [key: string]: any } | null {
-    return this.validateStartAtDate(startAtCtrl.value, this.flightForm && this.flightForm.get('contractEndAtFudged').value);
-  }
-
-  validateContractEndAt(endAtCtrl: AbstractControl): { [key: string]: any } | null {
-    return this.validateEndAtDate(this.flightForm && this.flightForm.get('contractStartAt').value, endAtCtrl.value);
   }
 
   validateStartAt(startAtCtrl: AbstractControl): { [key: string]: any } | null {

--- a/src/app/campaign/store/models/creative.models.ts
+++ b/src/app/campaign/store/models/creative.models.ts
@@ -19,6 +19,7 @@ export interface CreativeState {
   doc?: HalDoc;
   creative: Creative;
   page?: number;
+  text?: string;
   changed?: boolean;
   valid?: boolean;
 }

--- a/src/app/campaign/store/reducers/creative.reducer.spec.ts
+++ b/src/app/campaign/store/reducers/creative.reducer.spec.ts
@@ -56,12 +56,13 @@ describe('Creative Reducer', () => {
     const state = reducer(
       initialState,
       creativeActions.CreativeLoadListSuccess({
-        params: { page: 1 },
+        params: { page: 1, text: 'foo' },
         total: 2,
         docs: creativesFixture.map(doc => ({ creativeDoc: new MockHalDoc(doc), advertiserDoc: new MockHalDoc() }))
       })
     );
     expect(state.params.page).toEqual(1);
+    expect(state.params.text).toEqual('foo');
     expect(state.total).toEqual(2);
     expect(state.ids.length).toEqual(2);
     expect(state.entities[creativesFixture[0].id].creative.url).toEqual(creativesFixture[0].url);

--- a/src/app/campaign/store/reducers/creative.reducer.ts
+++ b/src/app/campaign/store/reducers/creative.reducer.ts
@@ -62,7 +62,8 @@ const _reducer = createReducer(
       action.docs.map(doc => ({
         doc: doc.creativeDoc,
         creative: docToCreative(doc.creativeDoc, doc.advertiserDoc),
-        page: action.params.page || 1
+        page: action.params.page || 1,
+        text: action.params.text || ''
       })),
       { ...state, params: action.params, total: action.total }
     )

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -154,7 +154,9 @@ const _reducer = createReducer(
             }
           : zone
       );
-    return localFlight ? adapter.updateOne({ id: localFlight.id, changes: { localFlight: { ...localFlight, zones } } }, state) : state;
+    return localFlight
+      ? adapter.updateOne({ id: localFlight.id, changes: { localFlight: { ...localFlight, zones }, changed: true } }, state)
+      : state;
   })
 );
 

--- a/src/app/campaign/store/selectors/creative.selectors.ts
+++ b/src/app/campaign/store/selectors/creative.selectors.ts
@@ -32,10 +32,17 @@ export const selectCreativeById = createSelector(
 
 export const selectShowCreativeListRoute = createSelector(selectRouterState, state => state && state.url.indexOf('creative/list') > -1);
 export const selectCreativeListCurrentPage = createSelector(selectCreativeParams, params => params && params.page);
-export const selectCreativeListPageOrderedByCreatedAt = createSelector(selectAllCreatives, selectCreativeListCurrentPage, (states, page) =>
-  states
-    // filter out any 'new' temp creatives on the state and filter to creatives on current page
-    .filter(state => state && state.creative && state.creative.createdAt && ((!page && state.page === 1) || state.page === page))
-    .map(state => state.creative)
-    .sort((a, b) => a.createdAt.valueOf() - b.createdAt.valueOf())
+export const selectCreativeListCurrentText = createSelector(selectCreativeParams, params => params && params.text);
+export const selectCreativeListPageOrderedByCreatedAt = createSelector(
+  selectAllCreatives,
+  selectCreativeListCurrentPage,
+  selectCreativeListCurrentText,
+  (states, page, text) =>
+    states
+      // filter out any 'new' temp creatives on the state and filter to creatives on current page/text
+      .filter(state => state && state.creative && state.creative.createdAt && ((!page && state.page === 1) || state.page === page))
+      // bit hacky, since the store is overwritten on every remote call ... but apply current text filter
+      .filter(state => (!text && state.text === '') || state.text === text)
+      .map(state => state.creative)
+      .sort((a, b) => a.createdAt.valueOf() - b.createdAt.valueOf())
 );

--- a/src/app/core/creative/creative.service.ts
+++ b/src/app/core/creative/creative.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin } from 'rxjs';
+import { Observable, forkJoin, of } from 'rxjs';
 import { mergeMap, map } from 'rxjs/operators';
 import { HalDoc } from 'ngx-prx-styleguide';
 import { AuguryService } from '../augury.service';
@@ -28,13 +28,18 @@ export class CreativeService {
         ...(params.text && { filters: `text=${params.text}` })
       })
       .pipe(
-        mergeMap((creativeDocs: HalDoc[]) =>
-          forkJoin(
-            creativeDocs.map(creativeDoc =>
-              creativeDoc.follow('prx:advertiser').pipe(map(advertiserDoc => ({ creativeDoc, advertiserDoc })))
-            )
-          )
-        )
+        mergeMap((creativeDocs: HalDoc[]) => {
+          // NOTE: forkJoin won't emit if we pass in an empty array
+          if (creativeDocs.length > 0) {
+            return forkJoin(
+              creativeDocs.map(creativeDoc =>
+                creativeDoc.follow('prx:advertiser').pipe(map(advertiserDoc => ({ creativeDoc, advertiserDoc })))
+              )
+            );
+          } else {
+            return of([]);
+          }
+        })
       );
   }
 


### PR DESCRIPTION
- [x] Fixes #305 - had to dig around a bit to avoid a large diff here.  The Creative store here is basically a global id=>object hash.  And the creatives-list filters it based on the current page param.  I amended that to also store the last `text` filter an object came in with, and filter the creatives-list by `text` as well.
- [x] Fixes #304 - remove contract date validations entirely, as Augury doesn't have them.  And it appears these are basically reporting-only fields.
- [x] Also fixed a minor bug where adding creatives to a flight didn't mark it as "changed".