### PR TITLE
Unique per booleans

### DIFF
--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -105,6 +105,8 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
     isCompanion: [false],
     zones: [''],
     targets: [''],
+    notUniquePerCampaign: [false],
+    notUniquePerAdvertiser: [false],
     set_inventory_uri: ['', Validators.required],
     allocationPriority: ['10', Validators.min(1)],
     totalGoal: ['', Validators.min(0)],
@@ -118,7 +120,11 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.formSubcription = this.flightForm.valueChanges.subscribe(flightFormModel => {
-      this.onFormValueChanges(flightFormModel);
+      this.onFormValueChanges({
+        ...flightFormModel,
+        uniquePerCampaign: !flightFormModel.notUniquePerCampaign,
+        uniquePerAdvertiser: !flightFormModel.notUniquePerAdvertiser
+      });
     });
   }
 
@@ -191,6 +197,9 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
   // updates the form from @Input() set flight
   setFlightForm(flight: Flight) {
     // patch values onto the form
-    this.flightForm.patchValue(flight, { emitEvent: false });
+    this.flightForm.patchValue(
+      { ...flight, notUniquePerCampaign: !flight.uniquePerCampaign, notUniquePerAdvertiser: !flight.uniquePerAdvertiser },
+      { emitEvent: false }
+    );
   }
 }

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -72,6 +72,15 @@
         [targetOptionsMap]="targetOptionsMap"
       ></grove-flight-targets>
     </div>
+    <div class="mat-form-field-wrapper flight-advanced">
+      <h2>Advanced</h2>
+      <div class="mat-form-field-wrapper">
+        <mat-checkbox formControlName="notUniquePerCampaign">Allow serving with other flights in this campaign</mat-checkbox>
+      </div>
+      <div class="mat-form-field-wrapper">
+        <mat-checkbox formControlName="notUniquePerAdvertiser">Allow serving with other flights from this same advertiser</mat-checkbox>
+      </div>
+    </div>
   </div>
   <div class="flight-controls-container">
     <button

--- a/src/app/campaign/flight/flight-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-form.component.spec.ts
@@ -94,6 +94,8 @@ class ParentFormComponent {
     contractEndAtFudged: [''],
     zones: [''],
     targets: [''],
+    notUniquePerCampaign: [false],
+    notUniquePerAdvertiser: [false],
     set_inventory_uri: ['', Validators.required],
     isCompanion: [false]
   });

--- a/src/app/campaign/store/models/flight.models.ts
+++ b/src/app/campaign/store/models/flight.models.ts
@@ -45,6 +45,8 @@ export interface Flight {
   contractEndAt?: Moment;
   contractEndAtFudged?: Moment;
   isCompanion?: boolean;
+  uniquePerCampaign?: boolean;
+  uniquePerAdvertiser?: boolean;
 }
 
 export interface FlightState {


### PR DESCRIPTION
Route through the `uniquePerCampaign` and `uniquePerAdvertiser` booleans.  Those default to "true" in Augury, so they're actually inversed in this form (I called them `notUniquePerCampaign` and `notUniquePerAdvertiser` to be ridiculously specific about it).

![image](https://user-images.githubusercontent.com/1410587/106815715-7b1f1f80-6631-11eb-8ba6-fe41b36abc81.png)
