### PR TITLE
Sales rep (and other fixes!)

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -2,6 +2,7 @@
 
 prx-header {
   max-width: 100%;
+  position: relative;
 }
 
 prx-header a {

--- a/src/app/campaign/form/campaign-form.component.html
+++ b/src/app/campaign/form/campaign-form.component.html
@@ -29,6 +29,11 @@
     </mat-form-field>
 
     <mat-form-field class="campaign-form-field" appearance="outline">
+      <mat-label>Sales Rep</mat-label>
+      <input matInput placeholder="Sales Rep" formControlName="salesRepName" />
+    </mat-form-field>
+
+    <mat-form-field class="campaign-form-field" appearance="outline">
       <mat-label>Owner</mat-label>
       <mat-select formControlName="set_account_uri" required>
         <mat-option *ngFor="let acct of accounts" [value]="acct.self_uri">{{ acct.name }}</mat-option>

--- a/src/app/campaign/form/campaign-form.component.ts
+++ b/src/app/campaign/form/campaign-form.component.ts
@@ -39,6 +39,7 @@ export class CampaignFormComponent implements OnInit {
     name: ['', Validators.required],
     type: ['', Validators.required],
     repName: ['', Validators.required],
+    salesRepName: [''],
     notes: [''],
     set_advertiser_uri: ['', [Validators.required, this.validateAdvertiser.bind(this)]]
   });
@@ -86,7 +87,7 @@ export class CampaignFormComponent implements OnInit {
   }
 
   updateCampaignForm(campaign: Campaign) {
-    const { name, type, repName, notes, set_account_uri, set_advertiser_uri } = campaign;
+    const { name, type, repName, salesRepName, notes, set_account_uri, set_advertiser_uri } = campaign;
 
     // set_advertiser_uri might be a typeahead advertiser name instead
     // NOTE: this fails if someone types a url as the advertiser name
@@ -98,6 +99,7 @@ export class CampaignFormComponent implements OnInit {
         ...(campaign.hasOwnProperty('name') && { name }),
         ...(campaign.hasOwnProperty('type') && { type }),
         ...(campaign.hasOwnProperty('repName') && { repName }),
+        ...(campaign.hasOwnProperty('salesRepName') && { salesRepName }),
         ...(campaign.hasOwnProperty('notes') && { notes }),
         ...(campaign.hasOwnProperty('set_account_uri') && { set_account_uri }),
         ...(!isAdvertiserName && { set_advertiser_uri })

--- a/src/app/campaign/store/models/campaign.models.ts
+++ b/src/app/campaign/store/models/campaign.models.ts
@@ -6,6 +6,7 @@ export interface Campaign {
   name: string;
   type: string;
   repName: string;
+  salesRepName?: string;
   notes: string;
   createdAt?: Date;
   set_account_uri: string;

--- a/src/app/campaign/store/reducers/flight.reducer.ts
+++ b/src/app/campaign/store/reducers/flight.reducer.ts
@@ -60,6 +60,8 @@ const _reducer = createReducer(
         endAt,
         endAtFudged: utc(endAt.valueOf()).subtract(1, 'days'),
         deliveryMode: 'capped',
+        uniquePerCampaign: true,
+        uniquePerAdvertiser: true,
         zones: [],
         set_inventory_uri: null
       },

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -283,7 +283,7 @@ export class DashboardService {
     this._error.next(null);
     this.loadList('prx:flights', 'prx:campaign,prx:advertiser', {
       ...params,
-      per: (params && params.per) || 25,
+      per: (params && params.per) || 100,
       sort: (params && params.sort) || 'start_at',
       direction: (params && params.direction) || 'asc'
     })

--- a/src/app/dashboard/filter/dashboard-filter.component.scss
+++ b/src/app/dashboard/filter/dashboard-filter.component.scss
@@ -37,9 +37,3 @@ h1 {
   grid-column-gap: 10px;
   justify-content: space-between;
 }
-.text {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(45vw, 1fr));
-  grid-column-gap: 10px;
-  justify-content: space-between;
-}

--- a/src/app/dashboard/filter/dashboard-filter.component.ts
+++ b/src/app/dashboard/filter/dashboard-filter.component.ts
@@ -17,6 +17,21 @@ import { DashboardService, DashboardParams, Facets, COMBINED_STATUS_FACETS } fro
       >
       </grove-filter-facet>
       <grove-filter-facet
+        facetName="Advertiser"
+        [options]="facets?.advertiser | labelOrder: 'label'"
+        [selectedOptions]="params?.advertiser"
+        (selectedOptionsChange)="routeToParams({ advertiser: $event })"
+      >
+      </grove-filter-facet>
+      <grove-filter-text textName="Campaign" [searchText]="params?.text" (search)="routeToParams({ text: $event })"> </grove-filter-text>
+      <grove-filter-facet
+        facetName="Type"
+        [options]="facets?.type"
+        [selectedOptions]="params?.type"
+        (selectedOptionsChange)="routeToParams({ type: $event })"
+      >
+      </grove-filter-facet>
+      <grove-filter-facet
         facetName="Zone"
         multiple="true"
         [options]="facets?.zone"
@@ -32,13 +47,8 @@ import { DashboardService, DashboardParams, Facets, COMBINED_STATUS_FACETS } fro
         (selectedOptionsChange)="routeToParams({ geo: $event })"
       >
       </grove-filter-facet>
-      <grove-filter-facet
-        facetName="Advertiser"
-        [options]="facets?.advertiser | labelOrder: 'label'"
-        [selectedOptions]="params?.advertiser"
-        (selectedOptionsChange)="routeToParams({ advertiser: $event })"
-      >
-      </grove-filter-facet>
+      <grove-filter-text textName="Rep Name" [searchText]="params?.representative" (search)="routeToParams({ representative: $event })">
+      </grove-filter-text>
       <grove-filter-facet
         facetName="Status"
         [options]="statusFacets"
@@ -46,18 +56,6 @@ import { DashboardService, DashboardParams, Facets, COMBINED_STATUS_FACETS } fro
         (selectedOptionsChange)="routeToParams({ status: $event })"
       >
       </grove-filter-facet>
-      <grove-filter-facet
-        facetName="Type"
-        [options]="facets?.type"
-        [selectedOptions]="params?.type"
-        (selectedOptionsChange)="routeToParams({ type: $event })"
-      >
-      </grove-filter-facet>
-    </div>
-    <div class="text">
-      <grove-filter-text textName="Campaign" [searchText]="params?.text" (search)="routeToParams({ text: $event })"> </grove-filter-text>
-      <grove-filter-text textName="Rep Name" [searchText]="params?.representative" (search)="routeToParams({ representative: $event })">
-      </grove-filter-text>
     </div>
   `,
   styleUrls: ['dashboard-filter.component.scss'],

--- a/src/app/dashboard/flight-table/flight-table.component.html
+++ b/src/app/dashboard/flight-table/flight-table.component.html
@@ -135,7 +135,7 @@
   <mat-paginator
     class="paginator"
     [length]="total"
-    [pageSize]="routedParams?.per || 25"
+    [pageSize]="routedParams?.per || 100"
     [pageIndex]="routedParams?.page - 1 || 0"
     [pageSizeOptions]="pageSizeOptions"
     showFirstLastButtons


### PR DESCRIPTION
- [x] Add a "sales rep" field to the campaign form (closes #303)
- [x] Reorder dashboard filters (closes #310)
- [x] Show 100 flights on dashboard (results in roughly 4x the load time) (closes #311)
- [x] Fix "allow serving with" defaults - should be unchecked for new flights
- [x] Fix app-switcher dropdown (just needed a CSS change)