### PR TITLE
#316: Remove FAB buttons from flight form

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -16,8 +16,8 @@ button[mat-fab] {
   right: 20px;
   bottom: 20px;
   background: mat-color($prx-green, 500);
-  padding: 0 10px;
-  border-radius: 20px;
+  padding: 0 14px;
+  border-radius: 28px;
   font-size: 14px;
   text-transform: uppercase;
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);

--- a/src/app/campaign/campaign.component.spec.ts
+++ b/src/app/campaign/campaign.component.spec.ts
@@ -27,6 +27,8 @@ import { CampaignNavComponent } from './nav/campaign-nav.component';
 import { CampaignErrorService } from './campaign-error.service';
 import { TestComponent, campaignRoutes } from '../../testing/test.component';
 import { campaignFixture, flightFixture } from './store/models/campaign-state.factory';
+import * as moment from 'moment';
+import { Flight } from './store/models';
 
 describe('CampaignComponent', () => {
   let component: CampaignComponent;
@@ -159,5 +161,29 @@ describe('CampaignComponent', () => {
     jest.spyOn(campaignActionService, 'addFlight');
     component.createFlight();
     expect(campaignActionService.addFlight).toHaveBeenCalled();
+  });
+
+  it('calls action to delete active flight flight', () => {
+    jest.spyOn(campaignActionService, 'deleteRoutedFlightToggle');
+    component.flightDeleteToggle();
+    expect(campaignActionService.deleteRoutedFlightToggle).toHaveBeenCalled();
+  });
+
+  it('calls action to duplicate active flight flight', () => {
+    const flightFixture: Flight = {
+      name: 'my-flight',
+      status: 'approved',
+      startAt: moment.utc(),
+      endAt: moment.utc(),
+      endAtFudged: moment.utc().subtract(1, 'days'),
+      totalGoal: 123,
+      zones: [{ id: 'pre_1' }],
+      targets: [],
+      set_inventory_uri: '/some/inventory',
+      deliveryMode: 'capped'
+    };
+    jest.spyOn(campaignActionService, 'dupFlight');
+    component.flightDuplicate(flightFixture);
+    expect(campaignActionService.dupFlight).toHaveBeenCalledWith(flightFixture);
   });
 });

--- a/src/app/campaign/campaign.component.ts
+++ b/src/app/campaign/campaign.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, OnInit, OnDestroy } from '@angular/
 import { ActivatedRoute } from '@angular/router';
 import { Observable, Subscription } from 'rxjs';
 import { Store, select } from '@ngrx/store';
-import { FlightState, Campaign } from './store/models';
+import { FlightState, Campaign, Flight } from './store/models';
 import {
   selectLocalCampaign,
   selectCampaignLoaded,
@@ -13,7 +13,8 @@ import {
   selectValid,
   selectChanged,
   selectLocalCampaignActualCount,
-  selectCampaignFlightInventoryReportData
+  selectCampaignFlightInventoryReportData,
+  selectRoutedLocalFlight
 } from './store/selectors';
 import * as accountActions from './store/actions/account-action.creator';
 import * as advertiserActions from './store/actions/advertiser-action.creator';
@@ -42,10 +43,13 @@ import { CampaignErrorService } from './campaign-error.service';
         <grove-campaign-nav
           [campaign]="campaign$ | async"
           [flights]="flights$ | async"
+          [activeFlight]="flightLocal$ | async"
           [valid]="valid$ | async"
           [changed]="changed$ | async"
           [isSaving]="campaignSaving$ | async"
           (createFlight)="createFlight()"
+          (flightDuplicate)="flightDuplicate($event)"
+          (flightDeleteToggle)="flightDeleteToggle()"
         ></grove-campaign-nav>
       </mat-drawer>
       <mat-drawer-content role="main">
@@ -63,6 +67,7 @@ import { CampaignErrorService } from './campaign-error.service';
 })
 export class CampaignComponent implements OnInit, OnDestroy {
   campaign$: Observable<Campaign>;
+  flightLocal$: Observable<Flight>;
   flights$: Observable<FlightState[]>;
   campaignLoaded$: Observable<boolean>;
   campaignLoading$: Observable<boolean>;
@@ -106,6 +111,7 @@ export class CampaignComponent implements OnInit, OnDestroy {
     this.campaignSaving$ = this.store.pipe(select(selectCampaignSaving));
     this.campaignName$ = this.store.pipe(select(selectLocalCampaignName));
     this.campaignActualCount$ = this.store.pipe(select(selectLocalCampaignActualCount));
+    this.flightLocal$ = this.store.pipe(select(selectRoutedLocalFlight));
     this.flights$ = this.store.pipe(select(selectAllFlightsOrderByCreatedAt));
     this.valid$ = this.store.pipe(select(selectValid));
     this.changed$ = this.store.pipe(select(selectChanged));
@@ -132,5 +138,13 @@ export class CampaignComponent implements OnInit, OnDestroy {
 
   createFlight() {
     this.campaignActionService.addFlight();
+  }
+
+  flightDuplicate(flight: Flight) {
+    this.campaignActionService.dupFlight(flight);
+  }
+
+  flightDeleteToggle() {
+    this.campaignActionService.deleteRoutedFlightToggle();
   }
 }

--- a/src/app/campaign/campaign.component.ts
+++ b/src/app/campaign/campaign.component.ts
@@ -14,7 +14,8 @@ import {
   selectChanged,
   selectLocalCampaignActualCount,
   selectCampaignFlightInventoryReportData,
-  selectRoutedLocalFlight
+  selectRoutedLocalFlight,
+  selectRoutedFlightDeleted
 } from './store/selectors';
 import * as accountActions from './store/actions/account-action.creator';
 import * as advertiserActions from './store/actions/advertiser-action.creator';
@@ -44,6 +45,7 @@ import { CampaignErrorService } from './campaign-error.service';
           [campaign]="campaign$ | async"
           [flights]="flights$ | async"
           [activeFlight]="flightLocal$ | async"
+          [softDeleted]="softDeleted$ | async"
           [valid]="valid$ | async"
           [changed]="changed$ | async"
           [isSaving]="campaignSaving$ | async"
@@ -68,6 +70,7 @@ import { CampaignErrorService } from './campaign-error.service';
 export class CampaignComponent implements OnInit, OnDestroy {
   campaign$: Observable<Campaign>;
   flightLocal$: Observable<Flight>;
+  softDeleted$: Observable<boolean>;
   flights$: Observable<FlightState[]>;
   campaignLoaded$: Observable<boolean>;
   campaignLoading$: Observable<boolean>;
@@ -112,6 +115,7 @@ export class CampaignComponent implements OnInit, OnDestroy {
     this.campaignName$ = this.store.pipe(select(selectLocalCampaignName));
     this.campaignActualCount$ = this.store.pipe(select(selectLocalCampaignActualCount));
     this.flightLocal$ = this.store.pipe(select(selectRoutedLocalFlight));
+    this.softDeleted$ = this.store.pipe(select(selectRoutedFlightDeleted));
     this.flights$ = this.store.pipe(select(selectAllFlightsOrderByCreatedAt));
     this.valid$ = this.store.pipe(select(selectValid));
     this.changed$ = this.store.pipe(select(selectChanged));

--- a/src/app/campaign/flight/flight-form-control-container.component.ts
+++ b/src/app/campaign/flight/flight-form-control-container.component.ts
@@ -24,9 +24,6 @@ import moment from 'moment';
         [targetOptionsMap]="targetOptionsMap"
         [statusOptions]="statusOptions"
         [flight]="flight"
-        [softDeleted]="softDeleted"
-        (flightDeleteToggle)="flightDeleteToggle.emit($event)"
-        (flightDuplicate)="flightDuplicate.emit($event)"
       ></grove-flight-form>
       <grove-inventory
         [flight]="flight"
@@ -61,8 +58,6 @@ export class FlightFormControlContainerComponent implements OnInit, OnDestroy {
   @Input() flightOverlapIsLoading: boolean;
   @Input() flightOverlapError: any;
   @Output() flightUpdate = new EventEmitter<{ flight: Flight; changed: boolean; valid: boolean }>(true);
-  @Output() flightDuplicate = new EventEmitter<Flight>(true);
-  @Output() flightDeleteToggle = new EventEmitter(true);
   formSubcription: Subscription;
   resetting = false;
 

--- a/src/app/campaign/flight/flight-form.component.html
+++ b/src/app/campaign/flight/flight-form.component.html
@@ -82,18 +82,4 @@
       </div>
     </div>
   </div>
-  <div class="flight-controls-container">
-    <button
-      (click)="onFlightDeleteToggle()"
-      mat-fab
-      [color]="softDeleted ? 'primary' : 'warn'"
-      [attr.aria-label]="softDeleted ? 'Restore flight' : 'Delete flight'"
-      *ngIf="canBeDeleted"
-    >
-      <mat-icon>{{ softDeleted ? 'restore_from_trash' : 'delete' }}</mat-icon>
-    </button>
-    <button (click)="onFlightDuplicate()" mat-fab color="primary" aria-label="Copy flight">
-      <mat-icon>file_copy</mat-icon>
-    </button>
-  </div>
 </mat-card>

--- a/src/app/campaign/flight/flight-form.component.spec.ts
+++ b/src/app/campaign/flight/flight-form.component.spec.ts
@@ -59,15 +59,7 @@ export const cannotStartInPast = control => (control.value.valueOf() > Date.now(
 @Component({
   template: `
     <form [formGroup]="flightForm">
-      <grove-flight-form
-        #childForm
-        [inventory]="inventory"
-        [zoneOptions]="zoneOptions"
-        [flight]="flight"
-        [softDeleted]="softDeleted"
-        (flightDeleteToggle)="flightDeleteToggle($event)"
-        (flightDuplicate)="flightDuplicate($event)"
-      ></grove-flight-form>
+      <grove-flight-form #childForm [inventory]="inventory" [zoneOptions]="zoneOptions" [flight]="flight"></grove-flight-form>
     </form>
   `
 })
@@ -79,9 +71,6 @@ class ParentFormComponent {
   inventory = inventoryFixture;
   zoneOptions = inventoryFixture[0].zones;
   flight = flightFixture;
-  softDeleted = false;
-  flightDeleteToggle = jest.fn(() => {});
-  flightDuplicate = jest.fn(() => {});
 
   flightForm = this.fb.group({
     id: [],
@@ -150,20 +139,6 @@ describe('FlightFormComponent', () => {
     parent = fixture.componentInstance;
     component = parent.childForm;
     fixture.detectChanges();
-  });
-
-  it('emits flight duplicate', done => {
-    parent.flight = flightFixture;
-    component.flightDuplicate.subscribe(toDup => {
-      expect(toDup).toMatchObject(flightFixture);
-      done();
-    });
-    component.onFlightDuplicate();
-  });
-
-  it('emits flight delete toggle', done => {
-    component.flightDeleteToggle.subscribe(() => done());
-    component.onFlightDeleteToggle();
   });
 
   it('checks for flight form errors', () => {

--- a/src/app/campaign/flight/flight-form.component.ts
+++ b/src/app/campaign/flight/flight-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core';
 import { FormGroup, AbstractControl, ControlContainer } from '@angular/forms';
 import { ErrorStateMatcher } from '@angular/material/core';
 import { Flight, Inventory, InventoryZone, InventoryTargetType, InventoryTargetsMap, FlightStatusOption } from '../store/models';
@@ -21,9 +21,6 @@ export class FlightFormComponent implements OnInit {
   @Input() targetTypes: InventoryTargetType[];
   @Input() targetOptionsMap: InventoryTargetsMap;
   @Input() statusOptions: FlightStatusOption[];
-  @Input() softDeleted: boolean;
-  @Output() flightDuplicate = new EventEmitter<Flight>(true);
-  @Output() flightDeleteToggle = new EventEmitter(true);
 
   flightForm: FormGroup;
 
@@ -32,18 +29,6 @@ export class FlightFormComponent implements OnInit {
   }
 
   constructor(private formContainer: ControlContainer) {}
-
-  onFlightDuplicate() {
-    this.flightDuplicate.emit(this.flight);
-  }
-
-  onFlightDeleteToggle() {
-    this.flightDeleteToggle.emit();
-  }
-
-  get canBeDeleted(): boolean {
-    return this.flight && !this.flight.actualCount;
-  }
 
   checkError(fieldName: string, type = 'error') {
     return this.flightForm.get(fieldName).getError(type);

--- a/src/app/campaign/flight/flight.container.ts
+++ b/src/app/campaign/flight/flight.container.ts
@@ -59,8 +59,6 @@ import { CampaignActionService } from '../store/actions/campaign-action.service'
           [previewError]="flightPreviewError$ | async"
           [flightActualsDateBoundaries]="flightActualsDateBoundaries$ | async"
           (flightUpdate)="flightUpdateFromForm($event)"
-          (flightDeleteToggle)="flightDeleteToggle()"
-          (flightDuplicate)="flightDuplicate($event)"
         ></grove-flight>
       </mat-drawer-content>
     </mat-drawer-container>
@@ -149,13 +147,5 @@ export class FlightContainerComponent implements OnInit, OnDestroy {
 
   flightUpdateFromForm({ flight: formFlight, changed, valid }: { flight: Flight; changed: boolean; valid: boolean }) {
     this.campaignAction.updateFlightForm(formFlight, changed, valid);
-  }
-
-  flightDuplicate(flight: Flight) {
-    this.campaignAction.dupFlight(flight);
-  }
-
-  flightDeleteToggle() {
-    this.campaignAction.deleteRoutedFlightToggle();
   }
 }

--- a/src/app/campaign/nav/campaign-nav.component.scss
+++ b/src/app/campaign/nav/campaign-nav.component.scss
@@ -4,43 +4,71 @@
   padding-top: 0;
 
   .mat-list-item {
-    transition: border-left 100ms ease-out 0ms;
+    position: relative;
     background: prx-theme-background(tab);
     color: prx-theme-foreground(tab);
     font-weight: 700;
     margin: 0 0 2px;
-    border-left: 0 solid $primary;
 
-    .mat-list-item-content {
+    ::ng-deep .mat-list-item-content {
       width: 100%;
+      padding-right: 0;
+    }
+
+    .menuBtn {
+      visibility: hidden;
+    }
+
+    &::before {
+      transition: left 100ms ease-out 0ms;
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      left: -4px;
+      bottom: 0;
+      width: 4px;
     }
 
     &:hover,
     &.active-link,
     &.changed {
-      border-left-width: 4px;
+      &::before {
+        left: 0;
+        background-color: $primary;
+      }
     }
 
     &.active-link {
       background: prx-theme-background(selected-tab);
       color: prx-theme-foreground(selected-tab);
+
+      .menuBtn {
+        visibility: visible;
+      }
     }
 
     &.changed {
       &.valid {
-        border-left-color: $success;
+        &::before {
+          background-color: $success;
+        }
       }
 
       &.invalid,
       &.error {
-        border-left-color: $warn;
+        &::before {
+          background-color: $warn;
+        }
       }
     }
 
     &.deleted-flight {
       text-decoration: line-through;
       color: $warn;
-      border-left-color: $warn;
+      &::before {
+        background-color: $warn;
+      }
     }
   }
 }

--- a/src/app/campaign/nav/campaign-nav.component.ts
+++ b/src/app/campaign/nav/campaign-nav.component.ts
@@ -31,9 +31,13 @@ import { Campaign, FlightState } from '../store/models';
         <mat-icon aria-hidden>file_copy</mat-icon>
         <span>Duplicate Flight</span>
       </button>
-      <button class="menuItem--warn" mat-menu-item (click)="onDelete()" *ngIf="canDeleteActiveFlight">
-        <mat-icon aria-hidden>delete</mat-icon>
+      <button class="menuItem--warn" mat-menu-item (click)="onDelete()" *ngIf="canDeleteActiveFlight && !softDeleted">
+        <mat-icon color="warn" aria-hidden>delete</mat-icon>
         <span>Delete Flight</span>
+      </button>
+      <button class="menuItem--primary" mat-menu-item (click)="onDelete()" *ngIf="softDeleted">
+        <mat-icon color="primary" aria-hidden>restore</mat-icon>
+        <span>Restore Flight</span>
       </button>
     </mat-menu>
   `,
@@ -43,6 +47,7 @@ import { Campaign, FlightState } from '../store/models';
 export class CampaignNavComponent {
   @Input() campaign: Campaign;
   @Input() activeFlight: Flight;
+  @Input() softDeleted: Boolean;
   @Input() flights: FlightState[];
   @Input() valid: boolean;
   @Input() changed: boolean;

--- a/src/app/campaign/nav/campaign-nav.component.ts
+++ b/src/app/campaign/nav/campaign-nav.component.ts
@@ -1,12 +1,13 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { Flight } from 'src/app/dashboard/dashboard.service';
 import { Campaign, FlightState } from '../store/models';
 
 @Component({
   selector: 'grove-campaign-nav',
   template: `
     <mat-nav-list>
-      <a mat-list-item routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }" routerLink="./">Campaign</a>
-      <a
+      <mat-list-item routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }" routerLink="./">Campaign</mat-list-item>
+      <mat-list-item
         mat-list-item
         *ngFor="let flight of flights; let i = index"
         [routerLink]="['flight', flight?.localFlight?.id]"
@@ -19,20 +20,56 @@ import { Campaign, FlightState } from '../store/models';
       >
         <span matLine>{{ flight.localFlight?.name }}</span>
         <mat-icon color="warn" *ngIf="!allocationStatusOk(flight)">priority_high</mat-icon>
-      </a>
+        <button class="menuBtn" mat-icon-button disableRipple [matMenuTriggerFor]="flightMenu" [disabled]="!isActiveFlight(flight)">
+          <mat-icon aria-label="Campaign Menu">more_vert</mat-icon>
+        </button>
+      </mat-list-item>
     </mat-nav-list>
     <a class="secondary-link" routerLink="" (click)="createFlight.emit()"><mat-icon>add</mat-icon> Add a Flight</a>
+    <mat-menu panelClass="menuPanel" #flightMenu="matMenu">
+      <button mat-menu-item (click)="onDuplicate()">
+        <mat-icon aria-hidden>file_copy</mat-icon>
+        <span>Duplicate Flight</span>
+      </button>
+      <button class="menuItem--warn" mat-menu-item (click)="onDelete()" *ngIf="canDeleteActiveFlight">
+        <mat-icon aria-hidden>delete</mat-icon>
+        <span>Delete Flight</span>
+      </button>
+    </mat-menu>
   `,
   styleUrls: ['./campaign-nav.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CampaignNavComponent {
   @Input() campaign: Campaign;
+  @Input() activeFlight: Flight;
   @Input() flights: FlightState[];
   @Input() valid: boolean;
   @Input() changed: boolean;
   @Input() isSaving: boolean;
   @Output() createFlight = new EventEmitter();
+  @Output() flightDuplicate = new EventEmitter<Flight>(true);
+  @Output() flightDeleteToggle = new EventEmitter(true);
+
+  onDuplicate() {
+    this.flightDuplicate.emit(this.activeFlight);
+  }
+
+  onDelete() {
+    this.flightDeleteToggle.emit();
+  }
+
+  isActiveFlight(flight: FlightState) {
+    return this.activeFlight && this.activeFlight?.id === flight.localFlight.id;
+  }
+
+  get activeFlightHasNoActuals() {
+    return this.activeFlight && !this.activeFlight.actualCount;
+  }
+
+  get canDeleteActiveFlight() {
+    return this.activeFlightHasNoActuals;
+  }
 
   allocationStatusOk(flight: FlightState): boolean {
     return !flight.localFlight.allocationStatus || flight.localFlight.allocationStatus === 'ok';

--- a/src/app/campaign/status/campaign-status.component.ts
+++ b/src/app/campaign/status/campaign-status.component.ts
@@ -22,11 +22,11 @@ import { FlightState } from '../store/models';
       <grove-campaign-report [campaignName]="campaignName" [flights]="flights" [reportData]="reportData"></grove-campaign-report>
       <button mat-menu-item [disabled]="!canDuplicate" (click)="onDuplicate()">
         <mat-icon aria-hidden>file_copy</mat-icon>
-        <span>Duplicate</span>
+        <span>Duplicate Campaign</span>
       </button>
       <button class="menuItem--warn" mat-menu-item [disabled]="!canDelete" (click)="onDelete()" *ngIf="hasNoActuals">
         <mat-icon aria-hidden>delete</mat-icon>
-        <span>Delete</span>
+        <span>Delete Campaign</span>
       </button>
     </mat-menu>
   `,

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -16,12 +16,14 @@ $prx-theme: mat-light-theme($prx-primary, $prx-accent, $prx-warn);
 //// Theme colors
 $primary: mat-color($prx-primary);
 $primary-contrast: mat-color($prx-primary, default-contrast);
+$primary-disabled: lighten($primary, 30%);
 $neutral: mat-color($prx-neutral);
 $neutral-contrast: mat-color($prx-neutral, default-contrast);
 $accent: mat-color($prx-accent);
 $accent-contrast: mat-color($prx-accent, default-contrast);
 $success: mat-color($prx-success);
 $success-contrast: mat-color($prx-success, default-contrast);
+$success-disabled: lighten($success, 30%);
 $warn: mat-color($prx-warn);
 $warn-contrast: mat-color($prx-warn, default-contrast);
 $warn-disabled: lighten($warn, 30%);

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -27,6 +27,14 @@ button.mat-button {
     }
   }
 
+  &.menuItem--primary {
+    color: $primary;
+
+    &[disabled] {
+      color: $primary-disabled;
+    }
+  }
+
   &[disabled] {
     background: none;
   }


### PR DESCRIPTION
Closes #316 

## This PR:
- Remove FAB buttons from flight form
- Adds context menu to campaign nav's flights' tabs to dup/delete active flight
- Fix border radius on new campaign button
- Update tests for flight form and campaign components