### PR TITLE
Dont load flights twice

### DIFF
--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -31,3 +31,8 @@ button.mat-button {
     background: none;
   }
 }
+
+// make sure snackbar is in above prx-header
+.cdk-overlay-container {
+  z-index: 10000;
+}


### PR DESCRIPTION
There's some code in the campaign service to `GET /api/v1/campaigns/123` with zoomed flights/flight-days.  It then checks if all the flights were present in that response (there's a `hal_api-rails` thing that only returns the first 10).  If not, it makes a 2nd request for `GET /api/v1/campaigns/123/flights?per=<total>` with zoomed flight-days.

Was seeing that 2nd request fire even when unnecessary.  This resolves that.

And adds a z-index so the material SnackBar is above the `prx-header`.